### PR TITLE
Patch unit tests by updating `OTIO_PLUGIN_MANIFEST_PATH` env var

### DIFF
--- a/tests/test_cdl.py
+++ b/tests/test_cdl.py
@@ -12,6 +12,10 @@ __doc__ = """Test CDL support in the EDL adapter."""
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 CDL_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "cdl.edl")
 
+os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = os.pathsep.join(
+    ["$OTIO_PLUGIN_MANIFEST_PATH", "../src/otio_cmx3600_adapter/plugin_manifest.json"]
+)
+
 
 class CDLAdapterTest(unittest.TestCase):
     def test_cdl_read(self):

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -15,6 +15,10 @@ import opentimelineio.test_utils as otio_test_utils
 from tempfile import TemporaryDirectory  # noqa: F401
 import tempfile
 
+os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = os.pathsep.join(
+    ["$OTIO_PLUGIN_MANIFEST_PATH", "../src/otio_cmx3600_adapter/plugin_manifest.json"]
+)
+
 # We import the cmx_3600 module this way to make sure the EDLParseError defined
 # in the module is properly caught. Importing the module and error directly
 # doesn't get accepted as the same exception when asserting in the


### PR DESCRIPTION
The unit tests modules were not functional without registering `otio_cmx3600_adapter/plugin_manifest.json` with the `OTIO_PLUGIN_MANIFEST_PATH` env var.