### PR TITLE
Switched to depend on 0.17.0.dev1 and ported tests to  pytest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        otio-version: ["extract_adapters"]
+        otio-version: ["0.17.0.dev1"]
         # TODO Once we have landed extracted adapters we replace otio-version
         #otio-version: ["0.15.0", "main"]
 
@@ -46,8 +46,6 @@ jobs:
           python -m pip install --upgrade pip
           if [[ "${{ matrix.otio-version }}" == "main" ]]; then
             pip install "git+https://github.com/AcademySoftwareFoundation/OpenTimelineIO.git"
-          elif [[ "${{ matrix.otio-version }}" == "extract_adapters" ]]; then
-            pip install "git+https://github.com/AcademySoftwareFoundation/OpenTimelineIO.git@${{ matrix.otio-version }}"
           else
             pip install -V OpenTimelineIO==${{ matrix.otio-version }}
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        otio-version: ["0.17.0.dev1"]
+        otio-version: ["0.17.0]
         # TODO Once we have landed extracted adapters we replace otio-version
         #otio-version: ["0.15.0", "main"]
 
@@ -47,7 +47,7 @@ jobs:
           if [[ "${{ matrix.otio-version }}" == "main" ]]; then
             pip install "git+https://github.com/AcademySoftwareFoundation/OpenTimelineIO.git"
           else
-            pip install -V OpenTimelineIO==${{ matrix.otio-version }}
+            pip install OpenTimelineIO>=${{ matrix.otio-version }} --pre --only-binary :all:
           fi
           pip install flake8 pytest pytest-cov
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,3 @@ otio_cmx3600_adapter = "otio_cmx3600_adapter"
 # Ensure the sdist includes a setup.py for older pip versions
 support-legacy = true
 exclude = [".github"]
-
-[tool.pytest.ini_options]
-pythonpath = [
-  "src"
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = { file="LICENSE" }
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
-    "opentimelineio >= 0.15.0"
+    "opentimelineio >= 0.17.0.dev1"
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,8 @@ otio_cmx3600_adapter = "otio_cmx3600_adapter"
 # Ensure the sdist includes a setup.py for older pip versions
 support-legacy = true
 exclude = [".github"]
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "src"
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,13 +4,11 @@ from pathlib import Path
 from pytest import fixture
 from opentimelineio import adapters, plugins
 
+import otio_cmx3600_adapter.cmx_3600
+
 
 @fixture
 def cmx_adapter():
-    manifest_path = (
-        Path(__file__).parent.parent / "src/otio_cmx3600_adapter/cmx_3600.py"
-    )
-
     # Use OTIO's native plugin loading system
     # This verifies that the adapter is being correctly registered and
     # discovered by OTIO.
@@ -23,7 +21,9 @@ def cmx_adapter():
     )
 
     # Assert that the loaded adapter is the local one.
-    assert Path(adapter.module_abs_path()) == manifest_path
+    assert Path(adapter.module_abs_path()) == Path(
+        otio_cmx3600_adapter.cmx_3600.__file__
+    )
     return adapter
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,23 @@ from opentimelineio import adapters, plugins
 @fixture
 def cmx_adapter():
     manifest_path = (
-        Path(__file__).parent.parent / "src/otio_cmx3600_adapter/plugin_manifest.json"
+        Path(__file__).parent.parent / "src/otio_cmx3600_adapter/cmx_3600.py"
     )
-    manifest = plugins.manifest.manifest_from_file(str(manifest_path))
-    return next(adapter for adapter in manifest.adapters if adapter.name == "cmx_3600")
+
+    # Use OTIO's native plugin loading system
+    # This verifies that the adapter is being correctly registered and
+    # discovered by OTIO.
+    # But it also means the tests require you to install the adapter before
+    # running the tests.
+    manifest = plugins.ActiveManifest()
+
+    adapter = next(
+        adapter for adapter in manifest.adapters if adapter.name == "cmx_3600"
+    )
+
+    # Assert that the loaded adapter is the local one.
+    assert Path(adapter.module_abs_path()) == manifest_path
+    return adapter
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import re
+from pathlib import Path
+
+from pytest import fixture
+from opentimelineio import adapters, plugins
+
+
+@fixture
+def cmx_adapter():
+    manifest_path = (
+        Path(__file__).parent.parent / "src/otio_cmx3600_adapter/plugin_manifest.json"
+    )
+    manifest = plugins.manifest.manifest_from_file(str(manifest_path))
+    return next(adapter for adapter in manifest.adapters if adapter.name == "cmx_3600")
+
+
+@fixture
+def assertJsonEqual():
+    """Convert to json and compare that (more readable)."""
+
+    def compare(known, test_result):
+        known_str = adapters.write_to_string(known, "otio_json")
+        test_str = adapters.write_to_string(test_result, "otio_json")
+
+        def strip_trailing_decimal_zero(s):
+            return re.sub(r'"(value|rate)": (\d+)\.0', r'"\1": \2', s)
+
+        assert strip_trailing_decimal_zero(known_str) == strip_trailing_decimal_zero(
+            test_str
+        )
+
+    return compare
+
+
+@fixture
+def assertIsOTIOEquivalentTo():
+    """Test using the 'is equivalent to' method on SerializableObject"""
+
+    return lambda known, test_result: known.is_equivalent_to(test_result) is True

--- a/tests/test_cdl.py
+++ b/tests/test_cdl.py
@@ -3,8 +3,8 @@
 
 # python
 import os
-import unittest
 
+import pytest
 import opentimelineio as otio
 
 __doc__ = """Test CDL support in the EDL adapter."""
@@ -13,45 +13,29 @@ SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 CDL_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "cdl.edl")
 
 
-class CDLAdapterTest(unittest.TestCase):
-    def test_cdl_read(self):
-        edl_path = CDL_EXAMPLE_PATH
-        timeline = otio.adapters.read_from_file(edl_path)
-        self.assertTrue(timeline is not None)
-        self.assertEqual(len(timeline.tracks), 1)
-        self.assertEqual(len(timeline.tracks[0]), 2)
-        for clip in timeline.tracks[0]:
-            # clip = timeline.tracks[0][0]
-            self.assertEqual(
-                clip.name,
-                "ZZ100_501 (LAY3)"
-            )
-            self.assertEqual(
-                clip.source_range.duration,
-                otio.opentime.from_timecode("00:00:01:07", 24)
-            )
-            cdl = clip.metadata.get("cdl", {})
-            self.assertEqual(
-                cdl.get("asc_sat"),
-                0.9
-            )
-            self.assertEqual(
-                list(cdl.get("asc_sop").get("slope")),
-                [0.1, 0.2, 0.3]
-            )
-            self.assertEqual(
-                list(cdl.get("asc_sop").get("offset")),
-                [1.0000, -0.0122, 0.0305]
-            )
-            self.assertEqual(
-                list(cdl.get("asc_sop").get("power")),
-                [1.0000, 0.0000, 1.0000]
-            )
+def test_cdl_read(cmx_adapter):
+    edl_path = CDL_EXAMPLE_PATH
+    timeline = cmx_adapter.read_from_file(edl_path)
+    assert timeline is not None
+    assert len(timeline.tracks) == 1
+    assert len(timeline.tracks[0]) == 2
+    for clip in timeline.tracks[0]:
+        # clip = timeline.tracks[0][0]
+        assert clip.name == "ZZ100_501 (LAY3)"
+        assert clip.source_range.duration == otio.opentime.from_timecode(
+            "00:00:01:07", 24
+        )
+        cdl = clip.metadata.get("cdl", {})
+        assert cdl.get("asc_sat") == 0.9
+        assert list(cdl.get("asc_sop").get("slope")) == [0.1, 0.2, 0.3]
+        assert list(cdl.get("asc_sop").get("offset")) == [1.0000, -0.0122, 0.0305]
+        assert list(cdl.get("asc_sop").get("power")) == [1.0000, 0.0000, 1.0000]
 
-    def test_cdl_read_with_commas(self):
-        # This EDL was generated with Premiere Pro using the CDL master effect
-        # on a clip
-        cdl = """TITLE: Sequence 01
+
+def test_cdl_read_with_commas(cmx_adapter):
+    # This EDL was generated with Premiere Pro using the CDL master effect
+    # on a clip
+    cdl = """TITLE: Sequence 01
 FCM: NON-DROP FRAME
 
 000001  A006C014_1701069O V     C        04:34:41:13 04:34:41:16 00:00:00:00 00:00:00:03
@@ -59,41 +43,38 @@ FCM: NON-DROP FRAME
 * ASC_SOP: (1.1549, 1.1469, 1.1422000000000001)(-0.067799999999999999, -0.055500000000000001, -0.032300000000000002)(1.1325000000000001, 1.1351, 1.1221000000000001)
 * ASC_SAT: 1.2988
 """  # noqa: E501
-        timeline = otio.adapters.read_from_string(cdl, "cmx_3600")
+    timeline = cmx_adapter.read_from_string(cdl)
 
-        clip = timeline.tracks[0][0]
-        cdl_metadata = clip.metadata["cdl"]
+    clip = timeline.tracks[0][0]
+    cdl_metadata = clip.metadata["cdl"]
 
-        ref_sop_values = {
-            "slope": [
-                1.1549,
-                1.1469,
-                1.1422000000000001,
-            ],
-            "offset": [
-                -0.067799999999999999,
-                -0.055500000000000001,
-                -0.032300000000000002,
-            ],
-            "power": [
-                1.1325000000000001,
-                1.1351,
-                1.1221000000000001,
-            ],
-        }
+    ref_sop_values = {
+        "slope": [
+            1.1549,
+            1.1469,
+            1.1422000000000001,
+        ],
+        "offset": [
+            -0.067799999999999999,
+            -0.055500000000000001,
+            -0.032300000000000002,
+        ],
+        "power": [
+            1.1325000000000001,
+            1.1351,
+            1.1221000000000001,
+        ],
+    }
 
-        self.assertAlmostEqual(cdl_metadata["asc_sat"], 1.2988)
-        for function in ("slope", "offset", "power"):
-            comparisons = zip(
-                cdl_metadata["asc_sop"][function], ref_sop_values[function]
-            )
-            for value_comp, ref_comp in comparisons:
-                self.assertAlmostEqual(
-                    value_comp, ref_comp, msg=f"mismatch in {function}"
-                )
+    assert cdl_metadata["asc_sat"] == pytest.approx(1.2988)
+    for function in ("slope", "offset", "power"):
+        comparisons = zip(cdl_metadata["asc_sop"][function], ref_sop_values[function])
+        for value_comp, ref_comp in comparisons:
+            assert value_comp == pytest.approx(ref_comp), f"mismatch in {function}"
 
-    def test_cdl_round_trip(self):
-        original = """TITLE: Example_Screening.01
+
+def test_cdl_round_trip(cmx_adapter):
+    original = """TITLE: Example_Screening.01
 
 001  AX       V     C        01:00:04:05 01:00:05:12 00:00:00:00 00:00:01:07
 * FROM CLIP NAME:  ZZ100_501 (LAY3)
@@ -101,7 +82,7 @@ FCM: NON-DROP FRAME
 *ASC_SAT 0.9
 * SOURCE FILE: ZZ100_501.LAY3.01
 """
-        expected = """TITLE: Example_Screening.01
+    expected = """TITLE: Example_Screening.01
 
 001  ZZ100501 V     C        01:00:04:05 01:00:05:12 00:00:00:00 00:00:01:07
 * FROM CLIP NAME:  ZZ100_501 (LAY3)
@@ -110,10 +91,6 @@ FCM: NON-DROP FRAME
 *ASC_SAT 0.9
 * SOURCE FILE: ZZ100_501.LAY3.01
 """
-        timeline = otio.adapters.read_from_string(original, "cmx_3600")
-        output = otio.adapters.write_to_string(timeline, "cmx_3600")
-        self.assertMultiLineEqual(expected, output)
-
-
-if __name__ == '__main__':
-    unittest.main()
+    timeline = cmx_adapter.read_from_string(original)
+    output = cmx_adapter.write_to_string(timeline)
+    assert expected == output

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -7,19 +7,11 @@
 
 # python
 import os
-import unittest
-
-import opentimelineio as otio
-import opentimelineio.test_utils as otio_test_utils
-
-from tempfile import TemporaryDirectory  # noqa: F401
 import tempfile
+from tempfile import TemporaryDirectory  # noqa: F401
 
-# We import the cmx_3600 module this way to make sure the EDLParseError defined
-# in the module is properly caught. Importing the module and error directly
-# doesn't get accepted as the same exception when asserting in the
-# `test_invalid_record_timecode` below.
-cmx_3600 = otio.adapters.from_name("cmx_3600").module()
+import pytest
+import opentimelineio as otio
 
 # List of sample files used in tests
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
@@ -37,809 +29,677 @@ GAP_TEST = os.path.join(SAMPLE_DATA_DIR, "gap_test.edl")
 WIPE_TEST = os.path.join(SAMPLE_DATA_DIR, "wipe_test.edl")
 TIMECODE_MISMATCH_TEST = os.path.join(SAMPLE_DATA_DIR, "timecode_mismatch.edl")
 SPEED_EFFECTS_TEST = os.path.join(SAMPLE_DATA_DIR, "speed_effects.edl")
-SPEED_EFFECTS_TEST_SMALL = os.path.join(SAMPLE_DATA_DIR,
-                                        "speed_effects_small.edl")
+SPEED_EFFECTS_TEST_SMALL = os.path.join(SAMPLE_DATA_DIR, "speed_effects_small.edl")
 MULTIPLE_TARGET_AUDIO_PATH = os.path.join(SAMPLE_DATA_DIR, "multi_audio.edl")
-TRANSITION_DURATION_TEST = os.path.join(SAMPLE_DATA_DIR,
-                                        "transition_duration.edl")
+TRANSITION_DURATION_TEST = os.path.join(SAMPLE_DATA_DIR, "transition_duration.edl")
 ENABLED_TEST = os.path.join(SAMPLE_DATA_DIR, "enabled.otio")
 
 
-class EDLAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
-    maxDiff = None
+def test_edl_read(cmx_adapter):
+    edl_path = SCREENING_EXAMPLE_PATH
+    fps = 24
+    timeline = cmx_adapter.read_from_file(edl_path)
+    assert timeline is not None
+    assert len(timeline.tracks) == 1
+    assert len(timeline.tracks[0]) == 9
+    assert timeline.tracks[0][0].name == "ZZ100_501 (LAY3)"
+    assert timeline.tracks[0][0].source_range.duration == otio.opentime.from_timecode(
+        "00:00:01:07", fps
+    )
+    assert timeline.tracks[0][1].name == "ZZ100_502A (LAY3)"
+    assert timeline.tracks[0][1].source_range.duration == otio.opentime.from_timecode(
+        "00:00:02:02", fps
+    )
+    assert timeline.tracks[0][2].name == "ZZ100_503A (LAY1)"
+    assert timeline.tracks[0][2].source_range.duration == otio.opentime.from_timecode(
+        "00:00:01:04", fps
+    )
+    assert timeline.tracks[0][3].name == "ZZ100_504C (LAY1)"
+    assert timeline.tracks[0][3].source_range.duration == otio.opentime.from_timecode(
+        "00:00:04:19", fps
+    )
 
-    def test_edl_read(self):
-        edl_path = SCREENING_EXAMPLE_PATH
-        fps = 24
-        timeline = otio.adapters.read_from_file(edl_path)
-        self.assertTrue(timeline is not None)
-        self.assertEqual(len(timeline.tracks), 1)
-        self.assertEqual(len(timeline.tracks[0]), 9)
-        self.assertEqual(
-            timeline.tracks[0][0].name,
-            "ZZ100_501 (LAY3)"
-        )
-        self.assertEqual(
-            timeline.tracks[0][0].source_range.duration,
-            otio.opentime.from_timecode("00:00:01:07", fps)
-        )
-        self.assertEqual(
-            timeline.tracks[0][1].name,
-            "ZZ100_502A (LAY3)"
-        )
-        self.assertEqual(
-            timeline.tracks[0][1].source_range.duration,
-            otio.opentime.from_timecode("00:00:02:02", fps)
-        )
-        self.assertEqual(
-            timeline.tracks[0][2].name,
-            "ZZ100_503A (LAY1)"
-        )
-        self.assertEqual(
-            timeline.tracks[0][2].source_range.duration,
-            otio.opentime.from_timecode("00:00:01:04", fps)
-        )
-        self.assertEqual(
-            timeline.tracks[0][3].name,
-            "ZZ100_504C (LAY1)"
-        )
-        self.assertEqual(
-            timeline.tracks[0][3].source_range.duration,
-            otio.opentime.from_timecode("00:00:04:19", fps)
-        )
+    assert len(timeline.tracks[0][3].markers) == 2
+    marker = timeline.tracks[0][3].markers[0]
+    assert marker.name == "ANIM FIX NEEDED"
+    assert marker.metadata.get("cmx_3600").get("color") == "RED"
+    assert marker.marked_range.start_time == otio.opentime.from_timecode(
+        "01:00:01:14", fps
+    )
+    assert marker.color == otio.schema.MarkerColor.RED
 
-        self.assertEqual(len(timeline.tracks[0][3].markers), 2)
-        marker = timeline.tracks[0][3].markers[0]
-        self.assertEqual(marker.name, "ANIM FIX NEEDED")
-        self.assertEqual(marker.metadata.get("cmx_3600").get("color"), "RED")
-        self.assertEqual(
-            marker.marked_range.start_time,
-            otio.opentime.from_timecode("01:00:01:14", fps)
-        )
-        self.assertEqual(marker.color, otio.schema.MarkerColor.RED)
+    unnamed_marker = timeline.tracks[0][6].markers[0]
+    assert unnamed_marker.name == ""
 
-        unnamed_marker = timeline.tracks[0][6].markers[0]
-        self.assertEqual(unnamed_marker.name, '')
+    assert timeline.tracks[0][4].name == "ZZ100_504B (LAY1)"
+    assert timeline.tracks[0][4].source_range.duration == otio.opentime.from_timecode(
+        "00:00:04:05", fps
+    )
+    assert timeline.tracks[0][5].name == "ZZ100_507C (LAY2)"
+    assert timeline.tracks[0][5].source_range.duration == otio.opentime.from_timecode(
+        "00:00:06:17", fps
+    )
+    assert timeline.tracks[0][6].name == "ZZ100_508 (LAY2)"
+    assert timeline.tracks[0][6].source_range.duration == otio.opentime.from_timecode(
+        "00:00:07:02", fps
+    )
+    assert timeline.tracks[0][7].name == "ZZ100_510 (LAY1)"
+    assert timeline.tracks[0][7].source_range.duration == otio.opentime.from_timecode(
+        "00:00:05:16", fps
+    )
+    assert timeline.tracks[0][8].name == "ZZ100_510B (LAY1)"
+    assert timeline.tracks[0][8].source_range.duration == otio.opentime.from_timecode(
+        "00:00:10:17", fps
+    )
 
-        self.assertEqual(
-            timeline.tracks[0][4].name,
-            "ZZ100_504B (LAY1)"
-        )
-        self.assertEqual(
-            timeline.tracks[0][4].source_range.duration,
-            otio.opentime.from_timecode("00:00:04:05", fps)
-        )
-        self.assertEqual(
-            timeline.tracks[0][5].name,
-            "ZZ100_507C (LAY2)"
-        )
-        self.assertEqual(
-            timeline.tracks[0][5].source_range.duration,
-            otio.opentime.from_timecode("00:00:06:17", fps)
-        )
-        self.assertEqual(
-            timeline.tracks[0][6].name,
-            "ZZ100_508 (LAY2)"
-        )
-        self.assertEqual(
-            timeline.tracks[0][6].source_range.duration,
-            otio.opentime.from_timecode("00:00:07:02", fps)
-        )
-        self.assertEqual(
-            timeline.tracks[0][7].name,
-            "ZZ100_510 (LAY1)"
-        )
-        self.assertEqual(
-            timeline.tracks[0][7].source_range.duration,
-            otio.opentime.from_timecode("00:00:05:16", fps)
-        )
-        self.assertEqual(
-            timeline.tracks[0][8].name,
-            "ZZ100_510B (LAY1)"
-        )
-        self.assertEqual(
-            timeline.tracks[0][8].source_range.duration,
-            otio.opentime.from_timecode("00:00:10:17", fps)
-        )
 
-    def test_reelname_length(self):
-        track = otio.schema.Track()
-        tl = otio.schema.Timeline("test_timeline", tracks=[track])
-        rt = otio.opentime.RationalTime(5.0, 24.0)
+def test_reelname_length(cmx_adapter):
+    track = otio.schema.Track()
+    tl = otio.schema.Timeline("test_timeline", tracks=[track])
+    rt = otio.opentime.RationalTime(5.0, 24.0)
 
-        long_mr = otio.schema.ExternalReference(
-            target_url="/var/tmp/test_a_really_really_long_filename.mov"
-        )
+    long_mr = otio.schema.ExternalReference(
+        target_url="/var/tmp/test_a_really_really_long_filename.mov"
+    )
 
-        tr = otio.opentime.TimeRange(
-            start_time=otio.opentime.RationalTime(0.0, 24.0),
-            duration=rt
-        )
+    tr = otio.opentime.TimeRange(
+        start_time=otio.opentime.RationalTime(0.0, 24.0), duration=rt
+    )
 
-        cl = otio.schema.Clip(
-            name="test clip1",
-            media_reference=long_mr,
-            source_range=tr,
-        )
+    cl = otio.schema.Clip(
+        name="test clip1",
+        media_reference=long_mr,
+        source_range=tr,
+    )
 
-        track.name = "V1"
-        track.append(cl)
+    track.name = "V1"
+    track.append(cl)
 
-        # Test default behavior
-        result = otio.adapters.write_to_string(tl, adapter_name="cmx_3600")
+    # Test default behavior
+    result = cmx_adapter.write_to_string(tl)
 
-        expected = '''TITLE: test_timeline
+    expected = """TITLE: test_timeline
 
 001  testarea V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 * FROM CLIP NAME:  test clip1
 * FROM CLIP: /var/tmp/test_a_really_really_long_filename.mov
 * OTIO TRUNCATED REEL NAME FROM: test_a_really_really_long_filename.mov
-'''
+"""
 
-        self.assertMultiLineEqual(result, expected)
+    assert result == expected
 
-        # Keep full filename (minus extension) as reelname
-        result = otio.adapters.write_to_string(
-            tl,
-            adapter_name="cmx_3600",
-            reelname_len=None
-        )
-        expected = '''TITLE: test_timeline
+    # Keep full filename (minus extension) as reelname
+    result = cmx_adapter.write_to_string(tl, reelname_len=None)
+    expected = """TITLE: test_timeline
 
 001  test_a_really_really_long_filename \
 V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 * FROM CLIP NAME:  test clip1
 * FROM CLIP: /var/tmp/test_a_really_really_long_filename.mov
-'''
+"""
 
-        self.assertMultiLineEqual(result, expected)
+    assert result == expected
 
-        # Make sure reel name is only 12 characters long
-        result = otio.adapters.write_to_string(
-            tl,
-            adapter_name="cmx_3600",
-            reelname_len=12
-        )
-        expected = '''TITLE: test_timeline
+    # Make sure reel name is only 12 characters long
+    result = cmx_adapter.write_to_string(tl, reelname_len=12)
+    expected = """TITLE: test_timeline
 
 001  testareallyr V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 * FROM CLIP NAME:  test clip1
 * FROM CLIP: /var/tmp/test_a_really_really_long_filename.mov
 * OTIO TRUNCATED REEL NAME FROM: test_a_really_really_long_filename.mov
-'''
+"""
 
-        self.assertMultiLineEqual(result, expected)
+    assert result == expected
 
-    def test_edl_round_trip_mem2disk2mem(self):
-        track = otio.schema.Track()
-        tl = otio.schema.Timeline("test_timeline", tracks=[track])
-        rt = otio.opentime.RationalTime(5.0, 24.0)
-        mr = otio.schema.ExternalReference(target_url="/var/tmp/test.mov")
-        md = {
-            "cmx_3600": {
-                "reel": "test",
-                "comments": ["OTIO TRUNCATED REEL NAME FROM: test.mov"]
-            }
+
+def test_edl_round_trip_mem2disk2mem(cmx_adapter, assertJsonEqual):
+    track = otio.schema.Track()
+    tl = otio.schema.Timeline("test_timeline", tracks=[track])
+    rt = otio.opentime.RationalTime(5.0, 24.0)
+    mr = otio.schema.ExternalReference(target_url="/var/tmp/test.mov")
+    md = {
+        "cmx_3600": {
+            "reel": "test",
+            "comments": ["OTIO TRUNCATED REEL NAME FROM: test.mov"],
         }
+    }
 
-        tr = otio.opentime.TimeRange(
-            start_time=otio.opentime.RationalTime(0.0, 24.0),
-            duration=rt
+    tr = otio.opentime.TimeRange(
+        start_time=otio.opentime.RationalTime(0.0, 24.0), duration=rt
+    )
+
+    cl = otio.schema.Clip(
+        name="test clip1", media_reference=mr, source_range=tr, metadata=md
+    )
+    cl2 = otio.schema.Clip(
+        name="test clip2", media_reference=mr.clone(), source_range=tr, metadata=md
+    )
+    cl3 = otio.schema.Clip(
+        name="test clip3", media_reference=mr.clone(), source_range=tr, metadata=md
+    )
+    cl4 = otio.schema.Clip(
+        name="test clip3_ff",
+        media_reference=mr.clone(),
+        source_range=tr,
+        metadata=md,
+    )
+
+    cl4.effects[:] = [otio.schema.FreezeFrame()]
+    cl5 = otio.schema.Clip(
+        name="test clip5 (speed)",
+        media_reference=mr.clone(),
+        source_range=tr,
+        metadata=md,
+    )
+    cl5.effects[:] = [otio.schema.LinearTimeWarp(time_scalar=2.0)]
+    track.name = "V"
+    track.append(cl)
+    track.extend([cl2, cl3])
+    track.append(cl4)
+    track.append(cl5)
+
+    result = cmx_adapter.write_to_string(tl)
+    new_otio = cmx_adapter.read_from_string(result)
+
+    # directly compare clip with speed effect
+    assert len(new_otio.tracks[0][3].effects) == 1
+    assert new_otio.tracks[0][3].name == tl.tracks[0][3].name
+
+    assertJsonEqual(new_otio, tl)
+
+    # ensure that an error is raised if more than one effect is present
+    cl5.effects.append(otio.schema.FreezeFrame())
+    with pytest.raises(otio.exceptions.NotSupportedError):
+        cmx_adapter.write_to_string(tl)
+
+    # blank effect should pass through and be ignored
+    cl5.effects[:] = [otio.schema.Effect()]
+    cmx_adapter.write_to_string(tl)
+
+    # but a timing effect should raise an exception
+    cl5.effects[:] = [otio.schema.TimeEffect()]
+    with pytest.raises(otio.exceptions.NotSupportedError):
+        cmx_adapter.write_to_string(tl)
+
+
+def test_edl_round_trip_disk2mem2disk_speed_effects(cmx_adapter, assertJsonEqual):
+    test_edl = SPEED_EFFECTS_TEST_SMALL
+    timeline = cmx_adapter.read_from_file(test_edl)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        tmp_path = os.path.join(
+            temp_dir, "test_edl_round_trip_disk2mem2disk_speed_effects.edl"
         )
 
-        cl = otio.schema.Clip(
-            name="test clip1",
-            media_reference=mr,
-            source_range=tr,
-            metadata=md
-        )
-        cl2 = otio.schema.Clip(
-            name="test clip2",
-            media_reference=mr.clone(),
-            source_range=tr,
-            metadata=md
-        )
-        cl3 = otio.schema.Clip(
-            name="test clip3",
-            media_reference=mr.clone(),
-            source_range=tr,
-            metadata=md
-        )
-        cl4 = otio.schema.Clip(
-            name="test clip3_ff",
-            media_reference=mr.clone(),
-            source_range=tr,
-            metadata=md
-        )
+        cmx_adapter.write_to_file(timeline, tmp_path)
 
-        cl4.effects[:] = [otio.schema.FreezeFrame()]
-        cl5 = otio.schema.Clip(
-            name="test clip5 (speed)",
-            media_reference=mr.clone(),
-            source_range=tr,
-            metadata=md
-        )
-        cl5.effects[:] = [otio.schema.LinearTimeWarp(time_scalar=2.0)]
-        track.name = "V"
-        track.append(cl)
-        track.extend([cl2, cl3])
-        track.append(cl4)
-        track.append(cl5)
+        result = cmx_adapter.read_from_file(tmp_path)
 
-        result = otio.adapters.write_to_string(tl, adapter_name="cmx_3600")
-        new_otio = otio.adapters.read_from_string(
-            result,
-            adapter_name="cmx_3600"
-        )
+        # When debugging, you can use this to see the difference in the OTIO
+        # cmx_3600.otio_json.write_to_file(timeline, "/tmp/original.otio")
+        # cmx_3600.otio_json.write_to_file(result, "/tmp/output.otio")
+        # os.system("xxdiff /tmp/{original,output}.otio")
 
-        # directly compare clip with speed effect
-        self.assertEqual(
-            len(new_otio.tracks[0][3].effects),
-            1
-        )
-        self.assertEqual(
-            new_otio.tracks[0][3].name,
-            tl.tracks[0][3].name
-        )
+        # When debugging, use this to see the difference in the EDLs on disk
+        # os.system("xxdiff {} {}&".format(test_edl, tmp_path))
 
-        self.assertJsonEqual(new_otio, tl)
+        # The in-memory OTIO representation should be the same
+    assertJsonEqual(timeline, result)
 
-        # ensure that an error is raised if more than one effect is present
-        cl5.effects.append(otio.schema.FreezeFrame())
-        with self.assertRaises(otio.exceptions.NotSupportedError):
-            otio.adapters.write_to_string(tl, "cmx_3600")
 
-        # blank effect should pass through and be ignored
-        cl5.effects[:] = [otio.schema.Effect()]
-        otio.adapters.write_to_string(tl, "cmx_3600")
+def test_edl_round_trip_disk2mem2disk(cmx_adapter, assertIsOTIOEquivalentTo):
+    timeline = cmx_adapter.read_from_file(SCREENING_EXAMPLE_PATH)
 
-        # but a timing effect should raise an exception
-        cl5.effects[:] = [otio.schema.TimeEffect()]
-        with self.assertRaises(otio.exceptions.NotSupportedError):
-            otio.adapters.write_to_string(tl, "cmx_3600")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        tmp_path = os.path.join(temp_dir, "test_edl_round_trip_disk2mem2disk.edl")
 
-    def test_edl_round_trip_disk2mem2disk_speed_effects(self):
-        test_edl = SPEED_EFFECTS_TEST_SMALL
-        timeline = otio.adapters.read_from_file(test_edl)
+        cmx_adapter.write_to_file(timeline, tmp_path)
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            tmp_path = os.path.join(
-                temp_dir,
-                "test_edl_round_trip_disk2mem2disk_speed_effects.edl"
-            )
+        result = cmx_adapter.read_from_file(tmp_path)
 
-            otio.adapters.write_to_file(timeline, tmp_path)
+        # When debugging, you can use this to see the difference in the OTIO
+        # cmx_3600.otio_json.write_to_file(timeline, "/tmp/original.otio")
+        # cmx_3600.otio_json.write_to_file(result, "/tmp/output.otio")
+        # os.system("opendiff /tmp/{original,output}.otio")
 
-            result = otio.adapters.read_from_file(tmp_path)
+        original_json = otio.adapters.write_to_string(timeline, "otio_json")
+        output_json = otio.adapters.write_to_string(result, "otio_json")
+        assert original_json == output_json
 
-            # When debugging, you can use this to see the difference in the OTIO
-            # otio.adapters.otio_json.write_to_file(timeline, "/tmp/original.otio")
-            # otio.adapters.otio_json.write_to_file(result, "/tmp/output.otio")
-            # os.system("xxdiff /tmp/{original,output}.otio")
+        # The in-memory OTIO representation should be the same
+        assertIsOTIOEquivalentTo(timeline, result)
 
-            # When debugging, use this to see the difference in the EDLs on disk
-            # os.system("xxdiff {} {}&".format(test_edl, tmp_path))
+        # When debugging, use this to see the difference in the EDLs on disk
+        # os.system("opendiff {} {}".format(SCREENING_EXAMPLE_PATH, tmp_path))
 
-            # The in-memory OTIO representation should be the same
-            self.assertJsonEqual(timeline, result)
+        # But the EDL text on disk are *not* byte-for-byte identical
+        with open(SCREENING_EXAMPLE_PATH) as original_file:
+            with open(tmp_path) as output_file:
+                assert original_file.read() != output_file.read()
 
-    def test_edl_round_trip_disk2mem2disk(self):
-        timeline = otio.adapters.read_from_file(SCREENING_EXAMPLE_PATH)
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            tmp_path = os.path.join(
-                temp_dir,
-                "test_edl_round_trip_disk2mem2disk.edl"
-            )
+def test_regex_flexibility(cmx_adapter, assertIsOTIOEquivalentTo):
+    timeline = cmx_adapter.read_from_file(SCREENING_EXAMPLE_PATH)
+    no_spaces = cmx_adapter.read_from_file(NO_SPACES_PATH)
+    assertIsOTIOEquivalentTo(timeline, no_spaces)
 
-            otio.adapters.write_to_file(timeline, tmp_path)
 
-            result = otio.adapters.read_from_file(tmp_path)
+def test_clip_with_tab_and_space_delimiters(cmx_adapter):
+    timeline = cmx_adapter.read_from_string(
+        "001  Z10 V  C\t\t01:00:04:05 01:00:05:12 00:59:53:11 00:59:54:18"
+    )
+    assert timeline is not None
+    assert len(timeline.tracks) == 1
+    assert timeline.tracks[0].kind == otio.schema.TrackKind.Video
+    assert len(timeline.tracks[0]) == 1
+    assert timeline.tracks[0][0].source_range.start_time.value == 86501
+    assert timeline.tracks[0][0].source_range.duration.value == 31
 
-            # When debugging, you can use this to see the difference in the OTIO
-            # otio.adapters.otio_json.write_to_file(timeline, "/tmp/original.otio")
-            # otio.adapters.otio_json.write_to_file(result, "/tmp/output.otio")
-            # os.system("opendiff /tmp/{original,output}.otio")
 
-            original_json = otio.adapters.otio_json.write_to_string(timeline)
-            output_json = otio.adapters.otio_json.write_to_string(result)
-            self.assertMultiLineEqual(original_json, output_json)
-
-            # The in-memory OTIO representation should be the same
-            self.assertIsOTIOEquivalentTo(timeline, result)
-
-            # When debugging, use this to see the difference in the EDLs on disk
-            # os.system("opendiff {} {}".format(SCREENING_EXAMPLE_PATH, tmp_path))
-
-            # But the EDL text on disk are *not* byte-for-byte identical
-            with open(SCREENING_EXAMPLE_PATH) as original_file:
-                with open(tmp_path) as output_file:
-                    self.assertNotEqual(original_file.read(),
-                                        output_file.read())
-
-    def test_regex_flexibility(self):
-        timeline = otio.adapters.read_from_file(SCREENING_EXAMPLE_PATH)
-        no_spaces = otio.adapters.read_from_file(NO_SPACES_PATH)
-        self.assertIsOTIOEquivalentTo(timeline, no_spaces)
-
-    def test_clip_with_tab_and_space_delimiters(self):
-        timeline = otio.adapters.read_from_string(
-            '001  Z10 V  C\t\t01:00:04:05 01:00:05:12 00:59:53:11 00:59:54:18',
-            adapter_name="cmx_3600"
-        )
-        self.assertTrue(timeline is not None)
-        self.assertEqual(len(timeline.tracks), 1)
-        self.assertEqual(
-            timeline.tracks[0].kind,
-            otio.schema.TrackKind.Video
-        )
-        self.assertEqual(len(timeline.tracks[0]), 1)
-        self.assertEqual(
-            timeline.tracks[0][0].source_range.start_time.value,
-            86501
-        )
-        self.assertEqual(
-            timeline.tracks[0][0].source_range.duration.value,
-            31
-        )
-
-    def test_imagesequence_read(self):
-        trunced_edl1 = '''TITLE: Image Sequence Write
+def test_imagesequence_read(cmx_adapter):
+    trunced_edl1 = """TITLE: Image Sequence Write
 
 001  myimages V     C        01:00:01:00 01:00:02:12 00:00:00:00 00:00:01:12
 * FROM CLIP NAME:  my_image_sequence
 * FROM CLIP: /media/path/my_image_sequence.[1025-1060].ext
 * OTIO TRUNCATED REEL NAME FROM: my_image_sequence.[1025-1060].ext
-'''
-        rate = 24
-        tl1 = otio.adapters.read_from_string(trunced_edl1, 'cmx_3600',
-                                             rate=rate)
-        self.assertIsInstance(tl1, otio.schema.Timeline)
+"""
+    rate = 24
+    tl1 = cmx_adapter.read_from_string(trunced_edl1, rate=rate)
+    assert isinstance(tl1, otio.schema.Timeline)
 
-        clip1 = tl1.tracks[0][0]
-        media_ref1 = clip1.media_reference
-        self.assertIsInstance(media_ref1, otio.schema.ImageSequenceReference)
-        self.assertEqual(media_ref1.start_frame, 1025)
-        self.assertEqual(media_ref1.end_frame(), 1060)
-        self.assertEqual(
-            clip1.available_range(),
-            otio.opentime.range_from_start_end_time(
-                otio.opentime.from_timecode('01:00:01:00', rate),
-                otio.opentime.from_timecode('01:00:02:12', rate)
-            )
-        )
+    clip1 = tl1.tracks[0][0]
+    media_ref1 = clip1.media_reference
+    assert isinstance(media_ref1, otio.schema.ImageSequenceReference)
+    assert media_ref1.start_frame == 1025
+    assert media_ref1.end_frame() == 1060
+    assert clip1.available_range() == otio.opentime.range_from_start_end_time(
+        otio.opentime.from_timecode("01:00:01:00", rate),
+        otio.opentime.from_timecode("01:00:02:12", rate),
+    )
 
-        # Make sure regex works and uses ExternalReference for non sequences
-        trunced_edl2 = '''TITLE: Image Sequence Write
+    # Make sure regex works and uses ExternalReference for non sequences
+    trunced_edl2 = """TITLE: Image Sequence Write
 
 001  myimages V     C        01:00:01:00 01:00:02:12 00:00:00:00 00:00:01:12
 * FROM CLIP NAME:  my_image_sequence
 * FROM CLIP: /media/path/my_image_file.1025.ext
 * OTIO TRUNCATED REEL NAME FROM: my_image_file.1025.ext
-'''
+"""
 
-        tl2 = otio.adapters.read_from_string(trunced_edl2, 'cmx_3600',
-                                             rate=rate)
-        clip2 = tl2.tracks[0][0]
-        media_ref2 = clip2.media_reference
-        self.assertIsInstance(media_ref2, otio.schema.ExternalReference)
+    tl2 = cmx_adapter.read_from_string(trunced_edl2, rate=rate)
+    clip2 = tl2.tracks[0][0]
+    media_ref2 = clip2.media_reference
+    assert isinstance(media_ref2, otio.schema.ExternalReference)
 
-        trunced_edl3 = '''TITLE: Image Sequence Write
+    trunced_edl3 = """TITLE: Image Sequence Write
 
 001  myimages V     C        01:00:01:00 01:00:02:12 00:00:00:00 00:00:01:12
 * FROM CLIP NAME:  my_image_sequence
 * FROM CLIP: /media/path/my_image_file.[1025].ext
 * OTIO TRUNCATED REEL NAME FROM: my_image_file.[1025].ext
-'''
-        tl3 = otio.adapters.read_from_string(trunced_edl3, 'cmx_3600',
-                                             rate=rate)
-        clip3 = tl3.tracks[0][0]
-        media_ref3 = clip3.media_reference
-        self.assertIsInstance(media_ref3, otio.schema.ExternalReference)
+"""
+    tl3 = cmx_adapter.read_from_string(trunced_edl3, rate=rate)
+    clip3 = tl3.tracks[0][0]
+    media_ref3 = clip3.media_reference
+    assert isinstance(media_ref3, otio.schema.ExternalReference)
 
-    def test_imagesequence_write(self):
-        rate = 24
-        tl = otio.schema.Timeline('Image Sequence Write')
-        track = otio.schema.Track('V1')
-        tl.tracks.append(track)
 
-        clip = otio.schema.Clip(
-            name='my_image_sequence',
-            source_range=otio.opentime.range_from_start_end_time(
-                otio.opentime.from_timecode('01:00:01:00', rate),
-                otio.opentime.from_timecode('01:00:02:12', rate)
+def test_imagesequence_write(cmx_adapter):
+    rate = 24
+    tl = otio.schema.Timeline("Image Sequence Write")
+    track = otio.schema.Track("V1")
+    tl.tracks.append(track)
+
+    clip = otio.schema.Clip(
+        name="my_image_sequence",
+        source_range=otio.opentime.range_from_start_end_time(
+            otio.opentime.from_timecode("01:00:01:00", rate),
+            otio.opentime.from_timecode("01:00:02:12", rate),
+        ),
+        media_reference=otio.schema.ImageSequenceReference(
+            target_url_base="/media/path/",
+            name_prefix="my_image_sequence.",
+            name_suffix=".ext",
+            rate=rate,
+            start_frame=1001,
+            frame_zero_padding=4,
+            available_range=otio.opentime.range_from_start_end_time(
+                otio.opentime.from_timecode("01:00:00:00", rate),
+                otio.opentime.from_timecode("01:00:03:00", rate),
             ),
-            media_reference=otio.schema.ImageSequenceReference(
-                target_url_base='/media/path/',
-                name_prefix='my_image_sequence.',
-                name_suffix='.ext',
-                rate=rate,
-                start_frame=1001,
-                frame_zero_padding=4,
-                available_range=otio.opentime.range_from_start_end_time(
-                    otio.opentime.from_timecode('01:00:00:00', rate),
-                    otio.opentime.from_timecode('01:00:03:00', rate)
-                )
-            )
-        )
-        track.append(clip)
+        ),
+    )
+    track.append(clip)
 
-        # Default behavior
-        result1 = otio.adapters.write_to_string(tl, 'cmx_3600', rate=rate)
+    # Default behavior
+    result1 = cmx_adapter.write_to_string(tl, rate=rate)
 
-        expected_result1 = '''TITLE: Image Sequence Write
+    expected_result1 = """TITLE: Image Sequence Write
 
 001  myimages V     C        01:00:01:00 01:00:02:12 00:00:00:00 00:00:01:12
 * FROM CLIP NAME:  my_image_sequence
 * FROM CLIP: /media/path/my_image_sequence.[1025-1060].ext
 * OTIO TRUNCATED REEL NAME FROM: my_image_sequence.[1025-1060].ext
-'''
-        self.assertMultiLineEqual(result1, expected_result1)
+"""
+    assert result1 == expected_result1
 
-        # Only trunc extension in reel name
-        result2 = otio.adapters.write_to_string(
-            tl,
-            'cmx_3600',
-            rate=24,
-            reelname_len=None
-        )
+    # Only trunc extension in reel name
+    result2 = cmx_adapter.write_to_string(tl, rate=24, reelname_len=None)
 
-        expected_result2 = '''TITLE: Image Sequence Write
+    expected_result2 = """TITLE: Image Sequence Write
 
 001  my_image_sequence.[1025-1060] V     C        \
 01:00:01:00 01:00:02:12 00:00:00:00 00:00:01:12
 * FROM CLIP NAME:  my_image_sequence
 * FROM CLIP: /media/path/my_image_sequence.[1025-1060].ext
-'''
-        self.assertMultiLineEqual(result2, expected_result2)
+"""
+    assert result2 == expected_result2
 
-    def test_dissolve_parse(self):
-        tl = otio.adapters.read_from_file(DISSOLVE_TEST)
-        # clip/transition/clip/clip
-        self.assertEqual(len(tl.tracks[0]), 4)
 
-        self.assertTrue(isinstance(tl.tracks[0][1], otio.schema.Transition))
-        self.assertEqual(tl.tracks[0][0].duration().value, 9)
-        # The visible range must contains all the frames needed for the transition
-        # Edit duration + transition duration
-        self.assertEqual(tl.tracks[0][0].visible_range().duration.to_frames(),
-                         19)
-        self.assertEqual(tl.tracks[0][0].name, "clip_A")
-        self.assertEqual(tl.tracks[0][1].duration().value, 10)
-        self.assertEqual(tl.tracks[0][1].name,
-                         "SMPTE_Dissolve from clip_A to clip_B")
-        self.assertEqual(tl.tracks[0][2].duration().value, 10)
-        self.assertEqual(tl.tracks[0][2].visible_range().duration.value, 10)
-        self.assertEqual(tl.tracks[0][2].name, "clip_B")
-        self.assertEqual(tl.tracks[0][3].duration().value, 1)
-        self.assertEqual(tl.tracks[0][2].name, "clip_B")
+def test_dissolve_parse(cmx_adapter):
+    tl = cmx_adapter.read_from_file(DISSOLVE_TEST)
+    # clip/transition/clip/clip
+    assert len(tl.tracks[0]) == 4
 
-    def test_dissolve_parse_middle(self):
-        tl = otio.adapters.read_from_file(DISSOLVE_TEST_2)
-        trck = tl.tracks[0]
-        # 3 clips and 1 transition
-        self.assertEqual(len(trck), 4)
+    assert isinstance(tl.tracks[0][1], otio.schema.Transition)
+    assert tl.tracks[0][0].duration().value == 9
+    # The visible range must contains all the frames needed for the transition
+    # Edit duration + transition duration
+    assert tl.tracks[0][0].visible_range().duration.to_frames() == 19
+    assert tl.tracks[0][0].name == "clip_A"
+    assert tl.tracks[0][1].duration().value == 10
+    assert tl.tracks[0][1].name == "SMPTE_Dissolve from clip_A to clip_B"
+    assert tl.tracks[0][2].duration().value == 10
+    assert tl.tracks[0][2].visible_range().duration.value == 10
+    assert tl.tracks[0][2].name == "clip_B"
+    assert tl.tracks[0][3].duration().value == 1
+    assert tl.tracks[0][2].name == "clip_B"
 
-        self.assertTrue(isinstance(trck[1], otio.schema.Transition))
 
-        self.assertEqual(trck[0].duration().value, 5)
-        self.assertEqual(trck[0].visible_range().duration.to_frames(), 15)
-        self.assertEqual(trck[1].duration().value, 10)
-        self.assertEqual(trck[1].name, "SMPTE_Dissolve from clip_A to clip_B")
+def test_dissolve_parse_middle(cmx_adapter):
+    tl = cmx_adapter.read_from_file(DISSOLVE_TEST_2)
+    trck = tl.tracks[0]
+    # 3 clips and 1 transition
+    assert len(trck) == 4
 
-        self.assertEqual(
-            trck[2].source_range.start_time.value,
-            otio.opentime.from_timecode('01:00:08:04', 24).value
-        )
-        self.assertEqual(trck[2].name, "clip_B")
-        self.assertEqual(trck[2].duration().value, 10)
-        self.assertEqual(trck[2].visible_range().duration.value, 10)
+    assert isinstance(trck[1], otio.schema.Transition)
 
-        self.assertEqual(tl.tracks[0][0].visible_range().duration.to_frames(),
-                         15)
+    assert trck[0].duration().value == 5
+    assert trck[0].visible_range().duration.to_frames() == 15
+    assert trck[1].duration().value == 10
+    assert trck[1].name == "SMPTE_Dissolve from clip_A to clip_B"
 
-    def test_dissolve_parse_full_clip_dissolve(self):
-        tl = otio.adapters.read_from_file(DISSOLVE_TEST_3)
-        self.assertEqual(len(tl.tracks[0]), 4)
+    assert (
+        trck[2].source_range.start_time.value
+        == otio.opentime.from_timecode("01:00:08:04", 24).value
+    )
+    assert trck[2].name == "clip_B"
+    assert trck[2].duration().value == 10
+    assert trck[2].visible_range().duration.value == 10
 
-        self.assertTrue(isinstance(tl.tracks[0][1], otio.schema.Transition))
+    assert tl.tracks[0][0].visible_range().duration.to_frames() == 15
 
-        trck = tl.tracks[0]
-        clip_a = trck[0]
-        self.assertEqual(clip_a.name, "Clip_A.mov")
-        self.assertEqual(clip_a.duration().value, 61)
-        self.assertEqual(clip_a.visible_range().duration.value, 61 + 30)
 
-        transition = trck[1]
-        # Note: clip names in the EDL are wrong, the transition is actually
-        # from Clip_A to Clip_B
-        self.assertEqual(
-            transition.name,
-            "SMPTE_Dissolve from Clip_B.mov to Clip_C.mov"
-        )
-        self.assertEqual(transition.in_offset.value, 0)
-        self.assertEqual(transition.out_offset.value, 30)
+def test_dissolve_parse_full_clip_dissolve(cmx_adapter):
+    tl = cmx_adapter.read_from_file(DISSOLVE_TEST_3)
+    assert len(tl.tracks[0]) == 4
 
-        clip_c = trck[2]
-        self.assertEqual(clip_c.name, "Clip_C.mov")
-        self.assertEqual(clip_c.source_range.start_time.value,
-                         86400 + (33 * 24 + 22))
-        self.assertEqual(clip_c.duration().value, 30)
-        self.assertEqual(clip_c.visible_range().duration.value, 30)
+    assert isinstance(tl.tracks[0][1], otio.schema.Transition)
 
-        clip_d = trck[3]
-        self.assertEqual(clip_d.name, "Clip_D.mov")
-        self.assertEqual(clip_d.source_range.start_time.value, 86400)
-        self.assertEqual(clip_d.duration().value, 46)
+    trck = tl.tracks[0]
+    clip_a = trck[0]
+    assert clip_a.name == "Clip_A.mov"
+    assert clip_a.duration().value == 61
+    assert clip_a.visible_range().duration.value == 61 + 30
 
-    def test_dissolve_with_odd_frame_count_maintains_length(self):
-        # EXERCISE
-        tl = otio.adapters.read_from_string(
-            '1 CLPA V C     00:00:04:17 00:00:07:02 00:00:00:00 00:00:02:09\n'
-            '2 CLPA V C     00:00:07:02 00:00:07:02 00:00:02:09 00:00:02:09\n'
-            '2 CLPB V D 027 00:00:06:18 00:00:07:21 00:00:02:09 00:00:03:12\n'
-            '3 CLPB V C     00:00:07:21 00:00:15:21 00:00:03:12 00:00:11:12\n',
-            adapter_name="cmx_3600"
-        )
+    transition = trck[1]
+    # Note: clip names in the EDL are wrong, the transition is actually
+    # from Clip_A to Clip_B
+    assert transition.name == "SMPTE_Dissolve from Clip_B.mov to Clip_C.mov"
+    assert transition.in_offset.value == 0
+    assert transition.out_offset.value == 30
 
-        # VALIDATE
-        self.assertEqual(tl.duration().value, (11 * 24) + 12)
+    clip_c = trck[2]
+    assert clip_c.name == "Clip_C.mov"
+    assert clip_c.source_range.start_time.value == 86400 + (33 * 24 + 22)
+    assert clip_c.duration().value == 30
+    assert clip_c.visible_range().duration.value == 30
 
-    def test_wipe_parse(self):
-        tl = otio.adapters.read_from_file(WIPE_TEST)
-        self.assertEqual(len(tl.tracks[0]), 4)
+    clip_d = trck[3]
+    assert clip_d.name == "Clip_D.mov"
+    assert clip_d.source_range.start_time.value == 86400
+    assert clip_d.duration().value == 46
 
-        wipe = tl.tracks[0][1]
-        self.assertTrue(isinstance(wipe, otio.schema.Transition))
-        self.assertEqual(wipe.transition_type, "SMPTE_Wipe")
-        self.assertEqual(wipe.metadata["cmx_3600"]["transition"], "W001")
 
-        self.assertEqual(tl.tracks[0][0].duration().value, 9)
-        self.assertEqual(tl.tracks[0][0].visible_range().duration.value, 19)
+def test_dissolve_with_odd_frame_count_maintains_length(cmx_adapter):
+    # EXERCISE
+    tl = cmx_adapter.read_from_string(
+        "1 CLPA V C     00:00:04:17 00:00:07:02 00:00:00:00 00:00:02:09\n"
+        "2 CLPA V C     00:00:07:02 00:00:07:02 00:00:02:09 00:00:02:09\n"
+        "2 CLPB V D 027 00:00:06:18 00:00:07:21 00:00:02:09 00:00:03:12\n"
+        "3 CLPB V C     00:00:07:21 00:00:15:21 00:00:03:12 00:00:11:12\n",
+    )
 
-        self.assertEqual(tl.tracks[0][2].duration().value, 10)
-        self.assertEqual(tl.tracks[0][2].visible_range().duration.value, 10)
+    # VALIDATE
+    assert tl.duration().value == (11 * 24) + 12
 
-        self.assertEqual(tl.tracks[0][3].duration().value, 1)
 
-    def test_fade_to_black(self):
-        # EXERCISE
-        tl = otio.adapters.read_from_string(
-            '1 CLPA V C     00:00:03:18 00:00:12:15 00:00:00:00 00:00:08:21\n'
-            '2 CLPA V C     00:00:12:15 00:00:12:15 00:00:08:21 00:00:08:21\n'
-            '2 BL   V D 024 00:00:00:00 00:00:01:00 00:00:08:21 00:00:09:21\n',
-            adapter_name="cmx_3600"
-        )
+def test_wipe_parse(cmx_adapter):
+    tl = cmx_adapter.read_from_file(WIPE_TEST)
+    assert len(tl.tracks[0]) == 4
 
-        # VALIDATE
-        self.assertEqual(len(tl.tracks[0]), 3)
-        self.assertTrue(isinstance(tl.tracks[0][1], otio.schema.Transition))
-        self.assertTrue(isinstance(tl.tracks[0][2], otio.schema.Clip))
-        self.assertEqual(tl.tracks[0][2].media_reference.generator_kind,
-                         'black')
-        self.assertEqual(tl.tracks[0][2].duration().value, 24)
-        self.assertEqual(tl.tracks[0][2].source_range.start_time.value, 0)
+    wipe = tl.tracks[0][1]
+    assert isinstance(wipe, otio.schema.Transition)
+    assert wipe.transition_type == "SMPTE_Wipe"
+    assert wipe.metadata["cmx_3600"]["transition"] == "W001"
 
-    def test_edl_round_trip_with_transitions(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Notes:
-            # - the writer does not handle wipes, only dissolves
-            # - the writer can generate invalid EDLs if spaces are in reel names.
-            for edl_file in [
-                DISSOLVE_TEST,
-                DISSOLVE_TEST_2,
-                DISSOLVE_TEST_3,
-                DISSOLVE_TEST_4
-            ]:
-                edl_name = os.path.basename(edl_file)
-                timeline = otio.adapters.read_from_file(edl_file)
-                tmp_path = os.path.join(
-                    temp_dir,
-                    f'test_edl_round_trip_{edl_name}'
-                )
-                otio.adapters.write_to_file(timeline, tmp_path)
+    assert tl.tracks[0][0].duration().value == 9
+    assert tl.tracks[0][0].visible_range().duration.value == 19
 
-                result = otio.adapters.read_from_file(tmp_path)
-                self.assertEqual(len(timeline.tracks), len(result.tracks))
-                for track, res_track in zip(timeline.tracks, result.tracks):
-                    self.assertEqual(len(track), len(res_track))
-                    for child, res_child in zip(track, res_track):
-                        self.assertEqual(type(child), type(res_child))
-                        if isinstance(child, otio.schema.Transition):
-                            self.assertEqual(child.in_offset,
-                                             res_child.in_offset)
-                            self.assertEqual(child.out_offset,
-                                             res_child.out_offset)
-                            self.assertEqual(
-                                child.transition_type, res_child.transition_type
-                            )
-                        else:
-                            self.assertEqual(child.source_range,
-                                             res_child.source_range)
+    assert tl.tracks[0][2].duration().value == 10
+    assert tl.tracks[0][2].visible_range().duration.value == 10
 
-    def test_edl_25fps(self):
-        # EXERCISE
-        edl_path = EXEMPLE_25_FPS_PATH
-        fps = 25
-        timeline = otio.adapters.read_from_file(edl_path, rate=fps)
-        track = timeline.tracks[0]
-        self.assertEqual(track[0].source_range.duration.value, 161)
-        self.assertEqual(track[1].source_range.duration.value, 200)
-        self.assertEqual(track[2].source_range.duration.value, 86)
-        self.assertEqual(track[3].source_range.duration.value, 49)
+    assert tl.tracks[0][3].duration().value == 1
 
-    def test_record_gaps(self):
-        edl_path = GAP_TEST
-        timeline = otio.adapters.read_from_file(edl_path)
-        track = timeline.tracks[0]
-        self.assertEqual(len(track), 5)
-        self.assertEqual(track.duration().value, 5 * 24 + 6)
-        clip1, gapA, clip2, gapB, clip3 = track[:]
-        self.assertEqual(clip1.source_range.duration.value, 24)
-        self.assertEqual(clip2.source_range.duration.value, 24)
-        self.assertEqual(clip3.source_range.duration.value, 24)
-        self.assertEqual(gapA.duration().value, 16)
-        self.assertEqual(gapB.duration().value, 38)
-        self.assertEqual(clip1.range_in_parent().duration.value, 24)
-        self.assertEqual(clip2.range_in_parent().duration.value, 24)
-        self.assertEqual(clip3.range_in_parent().duration.value, 24)
-        self.assertEqual(
-            [item.range_in_parent() for item in track],
-            [
-                otio.opentime.TimeRange(
-                    otio.opentime.from_frames(0, 24),
-                    otio.opentime.from_frames(24, 24)
+
+def test_fade_to_black(cmx_adapter):
+    # EXERCISE
+    tl = cmx_adapter.read_from_string(
+        "1 CLPA V C     00:00:03:18 00:00:12:15 00:00:00:00 00:00:08:21\n"
+        "2 CLPA V C     00:00:12:15 00:00:12:15 00:00:08:21 00:00:08:21\n"
+        "2 BL   V D 024 00:00:00:00 00:00:01:00 00:00:08:21 00:00:09:21\n",
+    )
+
+    # VALIDATE
+    assert len(tl.tracks[0]) == 3
+    assert isinstance(tl.tracks[0][1], otio.schema.Transition)
+    assert isinstance(tl.tracks[0][2], otio.schema.Clip)
+    assert tl.tracks[0][2].media_reference.generator_kind == "black"
+    assert tl.tracks[0][2].duration().value == 24
+    assert tl.tracks[0][2].source_range.start_time.value == 0
+
+
+def test_edl_round_trip_with_transitions(cmx_adapter):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Notes:
+        # - the writer does not handle wipes, only dissolves
+        # - the writer can generate invalid EDLs if spaces are in reel names.
+        for edl_file in [
+            DISSOLVE_TEST,
+            DISSOLVE_TEST_2,
+            DISSOLVE_TEST_3,
+            DISSOLVE_TEST_4,
+        ]:
+            edl_name = os.path.basename(edl_file)
+            timeline = cmx_adapter.read_from_file(edl_file)
+            tmp_path = os.path.join(temp_dir, f"test_edl_round_trip_{edl_name}")
+            cmx_adapter.write_to_file(timeline, tmp_path)
+
+            result = cmx_adapter.read_from_file(tmp_path)
+            assert len(timeline.tracks) == len(result.tracks)
+            for track, res_track in zip(timeline.tracks, result.tracks):
+                assert len(track) == len(res_track)
+                for child, res_child in zip(track, res_track):
+                    assert type(child) is type(res_child)
+                    if isinstance(child, otio.schema.Transition):
+                        assert child.in_offset == res_child.in_offset
+                        assert child.out_offset == res_child.out_offset
+                        assert child.transition_type == res_child.transition_type
+                    else:
+                        assert child.source_range == res_child.source_range
+
+
+def test_edl_25fps(cmx_adapter):
+    # EXERCISE
+    edl_path = EXEMPLE_25_FPS_PATH
+    fps = 25
+    timeline = cmx_adapter.read_from_file(edl_path, rate=fps)
+    track = timeline.tracks[0]
+    assert track[0].source_range.duration.value == 161
+    assert track[1].source_range.duration.value == 200
+    assert track[2].source_range.duration.value == 86
+    assert track[3].source_range.duration.value == 49
+
+
+def test_record_gaps(cmx_adapter):
+    edl_path = GAP_TEST
+    timeline = cmx_adapter.read_from_file(edl_path)
+    track = timeline.tracks[0]
+    assert len(track) == 5
+    assert track.duration().value == 5 * 24 + 6
+    clip1, gapA, clip2, gapB, clip3 = track[:]
+    assert clip1.source_range.duration.value == 24
+    assert clip2.source_range.duration.value == 24
+    assert clip3.source_range.duration.value == 24
+    assert gapA.duration().value == 16
+    assert gapB.duration().value == 38
+    assert clip1.range_in_parent().duration.value == 24
+    assert clip2.range_in_parent().duration.value == 24
+    assert clip3.range_in_parent().duration.value == 24
+    assert [item.range_in_parent() for item in track] == [
+        otio.opentime.TimeRange(
+            otio.opentime.from_frames(0, 24), otio.opentime.from_frames(24, 24)
+        ),
+        otio.opentime.TimeRange(
+            otio.opentime.from_frames(24, 24), otio.opentime.from_frames(16, 24)
+        ),
+        otio.opentime.TimeRange(
+            otio.opentime.from_frames(40, 24), otio.opentime.from_frames(24, 24)
+        ),
+        otio.opentime.TimeRange(
+            otio.opentime.from_frames(64, 24), otio.opentime.from_frames(38, 24)
+        ),
+        otio.opentime.TimeRange(
+            otio.opentime.from_frames(102, 24), otio.opentime.from_frames(24, 24)
+        ),
+    ]
+
+
+def test_read_generators(cmx_adapter):
+    # EXERCISE
+    tl = cmx_adapter.read_from_string(
+        "1 BL V C 00:00:00:00 00:00:01:00 00:00:00:00 00:00:01:00\n"
+        "2 BLACK V C 00:00:00:00 00:00:01:00 00:00:01:00 00:00:02:00\n"
+        "3 BARS V C 00:00:00:00 00:00:01:00 00:00:02:00 00:00:03:00\n",
+    )
+
+    # VALIDATE
+    assert tl.tracks[0][0].media_reference.generator_kind == "black"
+    assert tl.tracks[0][1].media_reference.generator_kind == "black"
+    assert tl.tracks[0][2].media_reference.generator_kind == "SMPTEBars"
+
+
+def test_style_edl_read(cmx_adapter, assertIsOTIOEquivalentTo):
+    edl_paths = [AVID_EXAMPLE_PATH, NUCODA_EXAMPLE_PATH, PREMIERE_EXAMPLE_PATH]
+    for edl_path in edl_paths:
+        fps = 24
+        timeline = cmx_adapter.read_from_file(edl_path)
+        assert timeline is not None
+        assert len(timeline.tracks) == 1
+        assert len(timeline.tracks[0]) == 2
+
+        # If cannot assertEqual fails with clip name
+        # Attempt to assertEqual with
+        try:
+            assert timeline.tracks[0][0].name == "take_1"
+        except AssertionError:
+            assert timeline.tracks[0][0].name == "ZZ100_501.take_1.0001.exr"
+        assert timeline.tracks[0][
+            0
+        ].source_range.duration == otio.opentime.from_timecode("00:00:01:07", fps)
+
+        try:
+            assertIsOTIOEquivalentTo(
+                timeline.tracks[0][0].media_reference,
+                otio.schema.ExternalReference(
+                    target_url=r"S:\path\to\ZZ100_501.take_1.0001.exr"
                 ),
-                otio.opentime.TimeRange(
-                    otio.opentime.from_frames(24, 24),
-                    otio.opentime.from_frames(16, 24)
-                ),
-                otio.opentime.TimeRange(
-                    otio.opentime.from_frames(40, 24),
-                    otio.opentime.from_frames(24, 24)
-                ),
-                otio.opentime.TimeRange(
-                    otio.opentime.from_frames(64, 24),
-                    otio.opentime.from_frames(38, 24)
-                ),
-                otio.opentime.TimeRange(
-                    otio.opentime.from_frames(102, 24),
-                    otio.opentime.from_frames(24, 24)
-                )
-            ]
-        )
-
-    def test_read_generators(self):
-        # EXERCISE
-        tl = otio.adapters.read_from_string(
-            '1 BL V C 00:00:00:00 00:00:01:00 00:00:00:00 00:00:01:00\n'
-            '2 BLACK V C 00:00:00:00 00:00:01:00 00:00:01:00 00:00:02:00\n'
-            '3 BARS V C 00:00:00:00 00:00:01:00 00:00:02:00 00:00:03:00\n',
-            adapter_name="cmx_3600"
-        )
-
-        # VALIDATE
-        self.assertEqual(
-            tl.tracks[0][0].media_reference.generator_kind,
-            'black'
-        )
-        self.assertEqual(
-            tl.tracks[0][1].media_reference.generator_kind,
-            'black'
-        )
-        self.assertEqual(
-            tl.tracks[0][2].media_reference.generator_kind,
-            'SMPTEBars'
-        )
-
-    def test_style_edl_read(self):
-        edl_paths = [AVID_EXAMPLE_PATH, NUCODA_EXAMPLE_PATH,
-                     PREMIERE_EXAMPLE_PATH]
-        for edl_path in edl_paths:
-            fps = 24
-            timeline = otio.adapters.read_from_file(edl_path)
-            self.assertTrue(timeline is not None)
-            self.assertEqual(len(timeline.tracks), 1)
-            self.assertEqual(len(timeline.tracks[0]), 2)
-
-            # If cannot assertEqual fails with clip name
-            # Attempt to assertEqual with
-            try:
-                self.assertEqual(
-                    timeline.tracks[0][0].name,
-                    "take_1"
-                )
-            except AssertionError:
-                self.assertEqual(
-                    timeline.tracks[0][0].name,
-                    "ZZ100_501.take_1.0001.exr"
-                )
-            self.assertEqual(
-                timeline.tracks[0][0].source_range.duration,
-                otio.opentime.from_timecode("00:00:01:07", fps)
+            )
+        except AssertionError:
+            assertIsOTIOEquivalentTo(
+                timeline.tracks[0][0].media_reference,
+                otio.schema.MissingReference(),
             )
 
-            try:
-                self.assertIsOTIOEquivalentTo(
-                    timeline.tracks[0][0].media_reference,
-                    otio.schema.ExternalReference(
-                        target_url=r"S:\path\to\ZZ100_501.take_1.0001.exr"
-                    )
-                )
-            except AssertionError:
-                self.assertIsOTIOEquivalentTo(
-                    timeline.tracks[0][0].media_reference,
-                    otio.schema.MissingReference()
-                )
+        try:
+            assert timeline.tracks[0][1].name == "take_2"
+        except AssertionError:
+            assert timeline.tracks[0][1].name == "ZZ100_502A.take_2.0101.exr"
 
-            try:
-                self.assertEqual(
-                    timeline.tracks[0][1].name,
-                    "take_2"
-                )
-            except AssertionError:
-                self.assertEqual(
-                    timeline.tracks[0][1].name,
-                    "ZZ100_502A.take_2.0101.exr"
-                )
+        assert timeline.tracks[0][
+            1
+        ].source_range.duration == otio.opentime.from_timecode("00:00:02:02", fps)
 
-            self.assertEqual(
-                timeline.tracks[0][1].source_range.duration,
-                otio.opentime.from_timecode("00:00:02:02", fps)
+        try:
+            assertIsOTIOEquivalentTo(
+                timeline.tracks[0][1].media_reference,
+                otio.schema.ExternalReference(
+                    target_url=r"S:\path\to\ZZ100_502A.take_2.0101.exr"
+                ),
+            )
+        except AssertionError:
+            assertIsOTIOEquivalentTo(
+                timeline.tracks[0][1].media_reference,
+                otio.schema.MissingReference(),
             )
 
-            try:
-                self.assertIsOTIOEquivalentTo(
-                    timeline.tracks[0][1].media_reference,
-                    otio.schema.ExternalReference(
-                        target_url=r"S:\path\to\ZZ100_502A.take_2.0101.exr"
-                    )
-                )
-            except AssertionError:
-                self.assertIsOTIOEquivalentTo(
-                    timeline.tracks[0][1].media_reference,
-                    otio.schema.MissingReference()
-                )
 
-    def test_style_edl_write(self):
-        track = otio.schema.Track()
-        tl = otio.schema.Timeline("temp", tracks=[track])
-        rt = otio.opentime.RationalTime(5.0, 24.0)
-        mr = otio.schema.ExternalReference(target_url=r"S:/var/tmp/test.exr")
+def test_style_edl_write(cmx_adapter):
+    track = otio.schema.Track()
+    tl = otio.schema.Timeline("temp", tracks=[track])
+    rt = otio.opentime.RationalTime(5.0, 24.0)
+    mr = otio.schema.ExternalReference(target_url=r"S:/var/tmp/test.exr")
 
-        tr = otio.opentime.TimeRange(
-            start_time=otio.opentime.RationalTime(0.0, 24.0),
-            duration=rt
+    tr = otio.opentime.TimeRange(
+        start_time=otio.opentime.RationalTime(0.0, 24.0), duration=rt
+    )
+    cl = otio.schema.Clip(
+        name="test clip1",
+        media_reference=mr,
+        source_range=tr,
+    )
+    gap = otio.schema.Gap(
+        source_range=otio.opentime.TimeRange(
+            start_time=otio.opentime.RationalTime(0, 24.0),
+            duration=otio.opentime.RationalTime(24.0, 24.0),
         )
-        cl = otio.schema.Clip(
-            name="test clip1",
-            media_reference=mr,
-            source_range=tr,
-        )
-        gap = otio.schema.Gap(
-            source_range=otio.opentime.TimeRange(
-                start_time=otio.opentime.RationalTime(0, 24.0),
-                duration=otio.opentime.RationalTime(24.0, 24.0),
-            )
-        )
-        cl2 = otio.schema.Clip(
-            name="test clip2",
-            media_reference=mr.clone(),
-            source_range=tr,
-        )
-        tl.tracks[0].name = "V"
-        tl.tracks[0].append(cl)
-        tl.tracks[0].append(gap)
-        tl.tracks[0].append(cl2)
+    )
+    cl2 = otio.schema.Clip(
+        name="test clip2",
+        media_reference=mr.clone(),
+        source_range=tr,
+    )
+    tl.tracks[0].name = "V"
+    tl.tracks[0].append(cl)
+    tl.tracks[0].append(gap)
+    tl.tracks[0].append(cl2)
 
-        tl.name = 'test_nucoda_timeline'
-        result = otio.adapters.write_to_string(
-            tl,
-            adapter_name='cmx_3600',
-            style='nucoda'
-        )
+    tl.name = "test_nucoda_timeline"
+    result = cmx_adapter.write_to_string(tl, style="nucoda")
 
-        expected = r'''TITLE: test_nucoda_timeline
+    expected = r"""TITLE: test_nucoda_timeline
 
 001  test     V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 * FROM CLIP NAME:  test clip1
@@ -849,18 +709,14 @@ V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 * FROM CLIP NAME:  test clip2
 * FROM FILE: S:/var/tmp/test.exr
 * OTIO TRUNCATED REEL NAME FROM: test.exr
-'''
+"""
 
-        self.assertMultiLineEqual(result, expected)
+    assert result == expected
 
-        tl.name = 'test_avid_timeline'
-        result = otio.adapters.write_to_string(
-            tl,
-            adapter_name='cmx_3600',
-            style='avid'
-        )
+    tl.name = "test_avid_timeline"
+    result = cmx_adapter.write_to_string(tl, style="avid")
 
-        expected = r'''TITLE: test_avid_timeline
+    expected = r"""TITLE: test_avid_timeline
 
 001  test     V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 * FROM CLIP NAME:  test clip1
@@ -870,18 +726,14 @@ V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 * FROM CLIP NAME:  test clip2
 * FROM CLIP: S:/var/tmp/test.exr
 * OTIO TRUNCATED REEL NAME FROM: test.exr
-'''
+"""
 
-        self.assertMultiLineEqual(result, expected)
+    assert result == expected
 
-        tl.name = 'test_premiere_timeline'
-        result = otio.adapters.write_to_string(
-            tl,
-            adapter_name='cmx_3600',
-            style='premiere'
-        )
+    tl.name = "test_premiere_timeline"
+    result = cmx_adapter.write_to_string(tl, style="premiere")
 
-        expected = r'''TITLE: test_premiere_timeline
+    expected = r"""TITLE: test_premiere_timeline
 
 001  AX       V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 * FROM CLIP NAME:  test.exr
@@ -891,13 +743,13 @@ V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 * FROM CLIP NAME:  test.exr
 * OTIO REFERENCE FROM: S:/var/tmp/test.exr
 * OTIO TRUNCATED REEL NAME FROM: test.exr
-'''
+"""
 
-        self.assertMultiLineEqual(result, expected)
+    assert result == expected
 
-    def test_reels_edl_round_trip_string2mem2string(self):
 
-        sample_data = r'''TITLE: Reels_Example.01
+def test_reels_edl_round_trip_string2mem2string(cmx_adapter):
+    sample_data = r"""TITLE: Reels_Example.01
 
 001  ZZ100_50 V     C        01:00:04:05 01:00:05:12 00:59:53:11 00:59:54:18
 * FROM CLIP NAME:  take_1
@@ -905,68 +757,59 @@ V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 002  ZZ100_50 V     C        01:00:06:13 01:00:08:15 00:59:54:18 00:59:56:20
 * FROM CLIP NAME:  take_2
 * FROM FILE: S:/path/to/ZZ100_502A.take_2.0101.exr
-'''
+"""
 
-        timeline = otio.adapters.read_from_string(sample_data,
-                                                  adapter_name="cmx_3600")
-        otio_data = otio.adapters.write_to_string(timeline,
-                                                  adapter_name="cmx_3600",
-                                                  style="nucoda")
-        self.assertMultiLineEqual(sample_data, otio_data)
+    timeline = cmx_adapter.read_from_string(sample_data)
+    otio_data = cmx_adapter.write_to_string(timeline, style="nucoda")
+    assert sample_data == otio_data
 
-    def test_nucoda_edl_write_with_transition(self):
-        track = otio.schema.Track()
-        tl = otio.schema.Timeline(
-            "Example CrossDissolve",
-            tracks=[track]
-        )
 
-        cl = otio.schema.Clip(
-            'Clip1',
-            metadata={'cmx_3600': {'reel': 'Clip1'}},
-            media_reference=otio.schema.ExternalReference(
-                target_url="/var/tmp/clip1.001.exr"
-            ),
-            source_range=otio.opentime.TimeRange(
-                start_time=otio.opentime.RationalTime(131.0, 24.0),
-                duration=otio.opentime.RationalTime(102.0, 24.0)
-            )
-        )
-        trans = otio.schema.Transition(
-            in_offset=otio.opentime.RationalTime(57.0, 24.0),
-            out_offset=otio.opentime.RationalTime(43.0, 24.0)
-        )
-        cl2 = otio.schema.Clip(
-            'Clip2',
-            metadata={'cmx_3600': {'reel': 'Clip2'}},
-            media_reference=otio.schema.ExternalReference(
-                target_url="/var/tmp/clip2.001.exr"
-            ),
-            source_range=otio.opentime.TimeRange(
-                start_time=otio.opentime.RationalTime(280.0, 24.0),
-                duration=otio.opentime.RationalTime(143.0, 24.0)
-            )
-        )
-        cl3 = otio.schema.Clip(
-            'Clip3',
-            metadata={'cmx_3600': {'reel': 'Clip3'}},
-            media_reference=otio.schema.ExternalReference(
-                target_url="/var/tmp/clip3.001.exr"
-            ),
-            source_range=otio.opentime.TimeRange(
-                start_time=otio.opentime.RationalTime(0.0, 24.0),
-                duration=otio.opentime.RationalTime(24.0, 24.0)
-            )
-        )
-        tl.tracks[0].extend([cl, trans, cl2, cl3])
+def test_nucoda_edl_write_with_transition(cmx_adapter):
+    track = otio.schema.Track()
+    tl = otio.schema.Timeline("Example CrossDissolve", tracks=[track])
 
-        result = otio.adapters.write_to_string(
-            tl,
-            adapter_name='cmx_3600',
-            style='nucoda'
-        )
+    cl = otio.schema.Clip(
+        "Clip1",
+        metadata={"cmx_3600": {"reel": "Clip1"}},
+        media_reference=otio.schema.ExternalReference(
+            target_url="/var/tmp/clip1.001.exr"
+        ),
+        source_range=otio.opentime.TimeRange(
+            start_time=otio.opentime.RationalTime(131.0, 24.0),
+            duration=otio.opentime.RationalTime(102.0, 24.0),
+        ),
+    )
+    trans = otio.schema.Transition(
+        in_offset=otio.opentime.RationalTime(57.0, 24.0),
+        out_offset=otio.opentime.RationalTime(43.0, 24.0),
+    )
+    cl2 = otio.schema.Clip(
+        "Clip2",
+        metadata={"cmx_3600": {"reel": "Clip2"}},
+        media_reference=otio.schema.ExternalReference(
+            target_url="/var/tmp/clip2.001.exr"
+        ),
+        source_range=otio.opentime.TimeRange(
+            start_time=otio.opentime.RationalTime(280.0, 24.0),
+            duration=otio.opentime.RationalTime(143.0, 24.0),
+        ),
+    )
+    cl3 = otio.schema.Clip(
+        "Clip3",
+        metadata={"cmx_3600": {"reel": "Clip3"}},
+        media_reference=otio.schema.ExternalReference(
+            target_url="/var/tmp/clip3.001.exr"
+        ),
+        source_range=otio.opentime.TimeRange(
+            start_time=otio.opentime.RationalTime(0.0, 24.0),
+            duration=otio.opentime.RationalTime(24.0, 24.0),
+        ),
+    )
+    tl.tracks[0].extend([cl, trans, cl2, cl3])
 
-        expected = r'''TITLE: Example CrossDissolve
+    result = cmx_adapter.write_to_string(tl, style="nucoda")
+
+    expected = r"""TITLE: Example CrossDissolve
 
 001  Clip1    V     C        00:00:05:11 00:00:07:08 00:00:00:00 00:00:01:21
 * FROM CLIP NAME:  Clip1
@@ -980,81 +823,69 @@ V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 003  Clip3    V     C        00:00:00:00 00:00:01:00 00:00:10:05 00:00:11:05
 * FROM CLIP NAME:  Clip3
 * FROM FILE: /var/tmp/clip3.001.exr
-'''
+"""
 
-        self.assertMultiLineEqual(result, expected)
+    assert result == expected
 
-    def test_nucoda_edl_write_fade_in(self):
-        track = otio.schema.Track()
-        tl = otio.schema.Timeline(
-            "Example Fade In",
-            tracks=[track]
-        )
 
-        trans = otio.schema.Transition(
-            in_offset=otio.opentime.RationalTime(0.0, 24.0),
-            out_offset=otio.opentime.RationalTime(12.0, 24.0)
-        )
-        cl = otio.schema.Clip(
-            'My Clip',
-            metadata={'cmx_3600': {'reel': 'My_Clip'}},
-            media_reference=otio.schema.ExternalReference(
-                target_url="/var/tmp/clip.001.exr"
-            ),
-            source_range=otio.opentime.TimeRange(
-                start_time=otio.opentime.RationalTime(50.0, 24.0),
-                duration=otio.opentime.RationalTime(26.0, 24.0)
-            )
-        )
-        tl.tracks[0].extend([trans, cl])
+def test_nucoda_edl_write_fade_in(cmx_adapter):
+    track = otio.schema.Track()
+    tl = otio.schema.Timeline("Example Fade In", tracks=[track])
 
-        result = otio.adapters.write_to_string(
-            tl,
-            adapter_name='cmx_3600',
-            style='nucoda'
-        )
+    trans = otio.schema.Transition(
+        in_offset=otio.opentime.RationalTime(0.0, 24.0),
+        out_offset=otio.opentime.RationalTime(12.0, 24.0),
+    )
+    cl = otio.schema.Clip(
+        "My Clip",
+        metadata={"cmx_3600": {"reel": "My_Clip"}},
+        media_reference=otio.schema.ExternalReference(
+            target_url="/var/tmp/clip.001.exr"
+        ),
+        source_range=otio.opentime.TimeRange(
+            start_time=otio.opentime.RationalTime(50.0, 24.0),
+            duration=otio.opentime.RationalTime(26.0, 24.0),
+        ),
+    )
+    tl.tracks[0].extend([trans, cl])
 
-        expected = r'''TITLE: Example Fade In
+    result = cmx_adapter.write_to_string(tl, style="nucoda")
+
+    expected = r"""TITLE: Example Fade In
 
 001  BL       V     C        00:00:00:00 00:00:00:00 00:00:00:00 00:00:00:00
 001  My_Clip  V     D 012    00:00:02:02 00:00:03:04 00:00:00:00 00:00:01:02
 * TO CLIP NAME:  My Clip
 * TO FILE: /var/tmp/clip.001.exr
-'''
+"""
 
-        self.assertMultiLineEqual(result, expected)
+    assert result == expected
 
-    def test_nucoda_edl_write_fade_out(self):
-        track = otio.schema.Track()
-        tl = otio.schema.Timeline(
-            "Example Fade Out",
-            tracks=[track]
-        )
 
-        cl = otio.schema.Clip(
-            'My Clip',
-            metadata={'cmx_3600': {'reel': 'My_Clip'}},
-            media_reference=otio.schema.ExternalReference(
-                target_url="/var/tmp/clip.001.exr"
-            ),
-            source_range=otio.opentime.TimeRange(
-                start_time=otio.opentime.RationalTime(24.0, 24.0),
-                duration=otio.opentime.RationalTime(24.0, 24.0)
-            )
-        )
-        trans = otio.schema.Transition(
-            in_offset=otio.opentime.RationalTime(12.0, 24.0),
-            out_offset=otio.opentime.RationalTime(0.0, 24.0)
-        )
-        tl.tracks[0].extend([cl, trans])
+def test_nucoda_edl_write_fade_out(cmx_adapter):
+    track = otio.schema.Track()
+    tl = otio.schema.Timeline("Example Fade Out", tracks=[track])
 
-        result = otio.adapters.write_to_string(
-            tl,
-            adapter_name='cmx_3600',
-            style='nucoda'
-        )
+    cl = otio.schema.Clip(
+        "My Clip",
+        metadata={"cmx_3600": {"reel": "My_Clip"}},
+        media_reference=otio.schema.ExternalReference(
+            target_url="/var/tmp/clip.001.exr"
+        ),
+        source_range=otio.opentime.TimeRange(
+            start_time=otio.opentime.RationalTime(24.0, 24.0),
+            duration=otio.opentime.RationalTime(24.0, 24.0),
+        ),
+    )
+    trans = otio.schema.Transition(
+        in_offset=otio.opentime.RationalTime(12.0, 24.0),
+        out_offset=otio.opentime.RationalTime(0.0, 24.0),
+    )
+    tl.tracks[0].extend([cl, trans])
 
-        expected = r'''TITLE: Example Fade Out
+    result = cmx_adapter.write_to_string(tl, style="nucoda")
+
+    expected = r"""TITLE: Example Fade Out
 
 001  My_Clip  V     C        00:00:01:00 00:00:01:12 00:00:00:00 00:00:00:12
 * FROM CLIP NAME:  My Clip
@@ -1063,272 +894,231 @@ V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 002  BL       V     D 012    00:00:00:00 00:00:00:12 00:00:00:12 00:00:01:00
 * FROM CLIP NAME:  My Clip
 * FROM FILE: /var/tmp/clip.001.exr
-'''
+"""
 
-        self.assertMultiLineEqual(result, expected)
+    assert result == expected
 
-    def test_nucoda_edl_write_with_double_transition(self):
-        track = otio.schema.Track()
-        tl = otio.schema.Timeline("Double Transition", tracks=[track])
 
-        cl = otio.schema.Clip(
-            metadata={'cmx_3600': {'reel': 'Reel1'}},
-            source_range=otio.opentime.TimeRange(
-                start_time=otio.opentime.RationalTime(24.0, 24.0),
-                duration=otio.opentime.RationalTime(24.0, 24.0)
-            )
-        )
-        trans = otio.schema.Transition(
-            in_offset=otio.opentime.RationalTime(6.0, 24.0),
-            out_offset=otio.opentime.RationalTime(6.0, 24.0)
-        )
-        cl2 = otio.schema.Clip(
-            metadata={'cmx_3600': {'reel': 'Reel2'}},
-            source_range=otio.opentime.TimeRange(
-                start_time=otio.opentime.RationalTime(24.0, 24.0),
-                duration=otio.opentime.RationalTime(24.0, 24.0)
-            )
-        )
-        trans2 = otio.schema.Transition(
-            in_offset=otio.opentime.RationalTime(6.0, 24.0),
-            out_offset=otio.opentime.RationalTime(6.0, 24.0)
-        )
-        cl3 = otio.schema.Clip(
-            metadata={'cmx_3600': {'reel': 'Reel3'}},
-            source_range=otio.opentime.TimeRange(
-                start_time=otio.opentime.RationalTime(24.0, 24.0),
-                duration=otio.opentime.RationalTime(24.0, 24.0)
-            )
-        )
-        tl.tracks[0].extend([cl, trans, cl2, trans2, cl3])
+def test_nucoda_edl_write_with_double_transition(cmx_adapter):
+    track = otio.schema.Track()
+    tl = otio.schema.Timeline("Double Transition", tracks=[track])
 
-        result = otio.adapters.write_to_string(
-            tl,
-            adapter_name='cmx_3600',
-            style='nucoda'
-        )
+    cl = otio.schema.Clip(
+        metadata={"cmx_3600": {"reel": "Reel1"}},
+        source_range=otio.opentime.TimeRange(
+            start_time=otio.opentime.RationalTime(24.0, 24.0),
+            duration=otio.opentime.RationalTime(24.0, 24.0),
+        ),
+    )
+    trans = otio.schema.Transition(
+        in_offset=otio.opentime.RationalTime(6.0, 24.0),
+        out_offset=otio.opentime.RationalTime(6.0, 24.0),
+    )
+    cl2 = otio.schema.Clip(
+        metadata={"cmx_3600": {"reel": "Reel2"}},
+        source_range=otio.opentime.TimeRange(
+            start_time=otio.opentime.RationalTime(24.0, 24.0),
+            duration=otio.opentime.RationalTime(24.0, 24.0),
+        ),
+    )
+    trans2 = otio.schema.Transition(
+        in_offset=otio.opentime.RationalTime(6.0, 24.0),
+        out_offset=otio.opentime.RationalTime(6.0, 24.0),
+    )
+    cl3 = otio.schema.Clip(
+        metadata={"cmx_3600": {"reel": "Reel3"}},
+        source_range=otio.opentime.TimeRange(
+            start_time=otio.opentime.RationalTime(24.0, 24.0),
+            duration=otio.opentime.RationalTime(24.0, 24.0),
+        ),
+    )
+    tl.tracks[0].extend([cl, trans, cl2, trans2, cl3])
 
-        expected = '''TITLE: Double Transition
+    result = cmx_adapter.write_to_string(tl, style="nucoda")
+
+    expected = """TITLE: Double Transition
 
 001  Reel1    V     C        00:00:01:00 00:00:01:18 00:00:00:00 00:00:00:18
 002  Reel1    V     C        00:00:01:18 00:00:01:18 00:00:00:18 00:00:00:18
 002  Reel2    V     D 012    00:00:00:18 00:00:01:18 00:00:00:18 00:00:01:18
 003  Reel2    V     C        00:00:01:18 00:00:01:18 00:00:01:18 00:00:01:18
 003  Reel3    V     D 012    00:00:00:18 00:00:02:00 00:00:01:18 00:00:03:00
-'''
+"""
 
-        self.assertMultiLineEqual(result, expected)
+    assert result == expected
 
-    def test_read_edl_with_multiple_target_audio_tracks(self):
-        tl = otio.adapters.read_from_file(MULTIPLE_TARGET_AUDIO_PATH)
 
-        self.assertEqual(len(tl.audio_tracks()), 2)
+def test_read_edl_with_multiple_target_audio_tracks(cmx_adapter):
+    tl = cmx_adapter.read_from_file(MULTIPLE_TARGET_AUDIO_PATH)
 
-        first_track, second_track = tl.audio_tracks()
-        self.assertEqual(first_track.name, "A1")
-        self.assertEqual(second_track.name, "A2")
+    assert len(tl.audio_tracks()) == 2
 
-        self.assertEqual(first_track[0].name, "AX")
-        self.assertEqual(second_track[0].name, "AX")
+    first_track, second_track = tl.audio_tracks()
+    assert first_track.name == "A1"
+    assert second_track.name == "A2"
 
-        expected_range = otio.opentime.TimeRange(
-            duration=otio.opentime.from_timecode("00:56:55:22", rate=24)
-        )
-        self.assertEqual(first_track[0].source_range, expected_range)
-        self.assertEqual(second_track[0].source_range, expected_range)
+    assert first_track[0].name == "AX"
+    assert second_track[0].name == "AX"
 
-    def test_custom_reel_names(self):
-        track = otio.schema.Track()
-        tl = otio.schema.Timeline(tracks=[track])
-        tr = otio.opentime.TimeRange(
-            start_time=otio.opentime.RationalTime(1.0, 24.0),
-            duration=otio.opentime.RationalTime(24.0, 24.0)
-        )
-        cl = otio.schema.Clip(
-            source_range=tr
-        )
-        cl.metadata['cmx_3600'] = {
-            'reel': 'v330_21f'
-        }
-        tl.tracks[0].append(cl)
+    expected_range = otio.opentime.TimeRange(
+        duration=otio.opentime.from_timecode("00:56:55:22", rate=24)
+    )
+    assert first_track[0].source_range == expected_range
+    assert second_track[0].source_range == expected_range
 
-        result = otio.adapters.write_to_string(
-            tl,
-            adapter_name='cmx_3600',
-            style='nucoda'
-        )
 
-        self.assertEqual(
-            result,
-            '001  v330_21f V     C        '
-            '00:00:00:01 00:00:01:01 00:00:00:00 00:00:01:00\n'
-        )
+def test_custom_reel_names(cmx_adapter):
+    track = otio.schema.Track()
+    tl = otio.schema.Timeline(tracks=[track])
+    tr = otio.opentime.TimeRange(
+        start_time=otio.opentime.RationalTime(1.0, 24.0),
+        duration=otio.opentime.RationalTime(24.0, 24.0),
+    )
+    cl = otio.schema.Clip(source_range=tr)
+    cl.metadata["cmx_3600"] = {"reel": "v330_21f"}
+    tl.tracks[0].append(cl)
 
-    def test_invalid_edl_style_raises_exception(self):
-        tl = otio.adapters.read_from_string(
-            '001  AX       V     C        '
-            '00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05\n',
-            adapter_name="cmx_3600"
-        )
-        with self.assertRaises(otio.exceptions.NotSupportedError):
-            otio.adapters.write_to_string(
-                tl,
-                adapter_name='cmx_3600',
-                style='bogus'
-            )
+    result = cmx_adapter.write_to_string(tl, style="nucoda")
 
-    def test_invalid_record_timecode(self):
-        with self.assertRaises(ValueError):
-            tl = otio.adapters.read_from_file(TIMECODE_MISMATCH_TEST)
-        with self.assertRaises(cmx_3600.EDLParseError):
-            tl = otio.adapters.read_from_file(TIMECODE_MISMATCH_TEST, rate=25)
+    assert (
+        result == "001  v330_21f V     C        "
+        "00:00:00:01 00:00:01:01 00:00:00:00 00:00:01:00\n"
+    )
 
-        tl = otio.adapters.read_from_file(
-            TIMECODE_MISMATCH_TEST,
-            rate=25,
-            ignore_timecode_mismatch=True
-        )
-        self.assertEqual(
-            tl.tracks[0][3].range_in_parent(),
-            otio.opentime.TimeRange(
-                start_time=otio.opentime.from_timecode("00:00:17:22", 25),
-                duration=otio.opentime.from_timecode("00:00:01:24", 25)
-            )
-        )
 
-    def test_can_read_frame_cut_points(self):
-        # EXERCISE
-        tl = otio.adapters.read_from_string(
-            '1 CLPA V C     113 170 0 57\n'
-            '2 CLPA V C     170 170 57 57\n'
-            '2 CLPB V D 027 162 189 57 84\n'
-            '3 CLPB V C     189 381 84 276\n',
-            adapter_name="cmx_3600"
-        )
+def test_invalid_edl_style_raises_exception(cmx_adapter):
+    tl = cmx_adapter.read_from_string(
+        "001  AX       V     C        "
+        "00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05\n",
+    )
+    with pytest.raises(otio.exceptions.NotSupportedError):
+        cmx_adapter.write_to_string(tl, style="bogus")
 
-        # VALIDATE
-        self.assertEqual(tl.duration().value, 276)
-        self.assertEqual(len(tl.tracks[0]), 4)
-        self.assertEqual(tl.tracks[0][0].duration().value, 57)
-        self.assertEqual(tl.tracks[0][0].visible_range().duration.value,
-                         57 + 27)
-        self.assertEqual(tl.tracks[0][1].in_offset.value, 0)
-        self.assertEqual(tl.tracks[0][1].out_offset.value, 27)
-        self.assertEqual(tl.tracks[0][2].duration().value, 27)
-        self.assertEqual(tl.tracks[0][3].duration().value, 276 - 84)
 
-    def test_speed_effects(self):
-        tl = otio.adapters.read_from_file(
-            SPEED_EFFECTS_TEST
-        )
-        self.assertEqual(
-            tl.duration(),
-            otio.opentime.from_timecode("00:21:03:18", 24)
-        )
+def test_invalid_record_timecode(cmx_adapter):
+    with pytest.raises(ValueError):
+        tl = cmx_adapter.read_from_file(TIMECODE_MISMATCH_TEST)
+    with pytest.raises(cmx_adapter.module().EDLParseError):
+        tl = cmx_adapter.read_from_file(TIMECODE_MISMATCH_TEST, rate=25)
 
-        # Look for a clip with a freeze frame effect
-        clip = tl.tracks[0][182]
-        self.assertEqual(clip.name, "Z682_156 (LAY3)")
-        self.assertTrue(
-            clip.effects and clip.effects[0].effect_name == 'FreezeFrame'
-        )
-        self.assertEqual(
-            clip.duration(),
-            otio.opentime.from_timecode("00:00:00:17", 24)
-        )
-        clip = tl.tracks[0][182]
-        # TODO: We should be able to ask for the source without the effect
-        # self.assertEqual(
-        #     clip.source_range,
-        #     otio.opentime.TimeRange(
-        #         start_time=otio.opentime.from_timecode("01:00:10:21", 24),
-        #         duration=otio.opentime.from_timecode("00:00:00:01", 24)
-        #     )
-        # )
-        self.assertEqual(
-            clip.range_in_parent(),
-            otio.opentime.TimeRange(
-                start_time=otio.opentime.from_timecode("00:08:30:00", 24),
-                duration=otio.opentime.from_timecode("00:00:00:17", 24)
-            )
-        )
+    tl = cmx_adapter.read_from_file(
+        TIMECODE_MISMATCH_TEST, rate=25, ignore_timecode_mismatch=True
+    )
+    assert tl.tracks[0][3].range_in_parent() == otio.opentime.TimeRange(
+        start_time=otio.opentime.from_timecode("00:00:17:22", 25),
+        duration=otio.opentime.from_timecode("00:00:01:24", 25),
+    )
 
-        # Look for a clip with an M2 effect
-        clip = tl.tracks[0][281]
-        self.assertEqual(
-            clip.name,
-            "Z686_5A (LAY2) (47.56 FPS)"
-        )
-        self.assertTrue(
-            clip.effects and clip.effects[0].effect_name == "LinearTimeWarp"
-        )
-        self.assertAlmostEqual(clip.effects[0].time_scalar, 1.98333333)
 
-        self.assertIsNone(
-            clip.metadata.get("cmx_3600", {}).get("motion")
-        )
-        self.assertEqual(
-            clip.duration(),
-            otio.opentime.from_timecode("00:00:01:12", 24)
-        )
-        # TODO: We should be able to ask for the source without the effect
-        # self.assertEqual(
-        #     clip.source_range,
-        #     otio.opentime.TimeRange(
-        #         start_time=otio.opentime.from_timecode("01:00:06:00", 24),
-        #         duration=otio.opentime.from_timecode("00:00:02:22", 24)
-        #     )
-        # )
-        self.assertEqual(
-            clip.range_in_parent(),
-            otio.opentime.TimeRange(
-                start_time=otio.opentime.from_timecode("00:11:31:16", 24),
-                duration=otio.opentime.from_timecode("00:00:01:12", 24)
-            )
-        )
+def test_can_read_frame_cut_points(cmx_adapter):
+    # EXERCISE
+    tl = cmx_adapter.read_from_string(
+        "1 CLPA V C     113 170 0 57\n"
+        "2 CLPA V C     170 170 57 57\n"
+        "2 CLPB V D 027 162 189 57 84\n"
+        "3 CLPB V C     189 381 84 276\n",
+    )
 
-    def test_transition_duration(self):
-        tl = otio.adapters.read_from_file(TRANSITION_DURATION_TEST)
-        self.assertEqual(len(tl.tracks[0]), 5)
+    # VALIDATE
+    assert tl.duration().value == 276
+    assert len(tl.tracks[0]) == 4
+    assert tl.tracks[0][0].duration().value == 57
+    assert tl.tracks[0][0].visible_range().duration.value == 57 + 27
+    assert tl.tracks[0][1].in_offset.value == 0
+    assert tl.tracks[0][1].out_offset.value == 27
+    assert tl.tracks[0][2].duration().value == 27
+    assert tl.tracks[0][3].duration().value == 276 - 84
 
-        self.assertIsInstance(tl.tracks[0][2], otio.schema.Transition)
 
-        self.assertEqual(tl.tracks[0][2].duration().value, 26.0)
+def test_speed_effects(cmx_adapter):
+    tl = cmx_adapter.read_from_file(SPEED_EFFECTS_TEST)
+    assert tl.duration() == otio.opentime.from_timecode("00:21:03:18", 24)
 
-    def test_three_part_transition(self):
-        """
-        Test A->B->C Transition
-        """
-        tl = otio.adapters.read_from_file(DISSOLVE_TEST_4)
-        self.assertEqual(len(tl.tracks[0]), 8)
+    # Look for a clip with a freeze frame effect
+    clip = tl.tracks[0][182]
+    assert clip.name == "Z682_156 (LAY3)"
+    assert clip.effects and clip.effects[0].effect_name == "FreezeFrame"
+    assert clip.duration() == otio.opentime.from_timecode("00:00:00:17", 24)
+    clip = tl.tracks[0][182]
+    # TODO: We should be able to ask for the source without the effect
+    # self.assertEqual(
+    #     clip.source_range,
+    #     otio.opentime.TimeRange(
+    #         start_time=otio.opentime.from_timecode("01:00:10:21", 24),
+    #         duration=otio.opentime.from_timecode("00:00:00:01", 24)
+    #     )
+    # )
+    assert clip.range_in_parent() == otio.opentime.TimeRange(
+        start_time=otio.opentime.from_timecode("00:08:30:00", 24),
+        duration=otio.opentime.from_timecode("00:00:00:17", 24),
+    )
 
-        self.assertEqual(tl.tracks[0][0].duration().value, 30.0)
-        self.assertEqual(tl.tracks[0][1].duration().value, 51.0)
-        self.assertEqual(tl.tracks[0][1].visible_range().duration.value,
-                         51 + 35)
-        self.assertIsInstance(tl.tracks[0][2], otio.schema.Transition)
-        self.assertEqual(tl.tracks[0][2].duration().value, 35.0)
-        self.assertEqual(tl.tracks[0][3].duration().value, 81.0)
-        self.assertEqual(tl.tracks[0][3].visible_range().duration.value,
-                         81 + 64)
-        self.assertIsInstance(tl.tracks[0][4], otio.schema.Transition)
-        self.assertEqual(tl.tracks[0][4].duration().value, 64.0)
-        self.assertEqual(tl.tracks[0][5].duration().value, 84.0)
-        self.assertEqual(tl.tracks[0][5].visible_range().duration.value, 84.0)
-        self.assertEqual(tl.tracks[0][6].duration().value, 96.0)
-        self.assertEqual(tl.tracks[0][7].duration().value, 135.0)
+    # Look for a clip with an M2 effect
+    clip = tl.tracks[0][281]
+    assert clip.name == "Z686_5A (LAY2) (47.56 FPS)"
+    assert clip.effects and clip.effects[0].effect_name == "LinearTimeWarp"
+    assert abs(clip.effects[0].time_scalar - 1.98333333) == pytest.approx(
+        0, abs=0.0000001
+    )
 
-    def test_enabled(self):
-        tl = otio.adapters.read_from_file(ENABLED_TEST)
-        # Exception is raised because the OTIO file has two tracks and cmx_3600 only
-        # supports one
-        with self.assertRaises(otio.exceptions.NotSupportedError):
-            otio.adapters.write_to_string(tl, adapter_name="cmx_3600")
+    assert clip.metadata.get("cmx_3600", {}).get("motion") is None
+    assert clip.duration() == otio.opentime.from_timecode("00:00:01:12", 24)
+    # TODO: We should be able to ask for the source without the effect
+    # self.assertEqual(
+    #     clip.source_range,
+    #     otio.opentime.TimeRange(
+    #         start_time=otio.opentime.from_timecode("01:00:06:00", 24),
+    #         duration=otio.opentime.from_timecode("00:00:02:22", 24)
+    #     )
+    # )
+    assert clip.range_in_parent() == otio.opentime.TimeRange(
+        start_time=otio.opentime.from_timecode("00:11:31:16", 24),
+        duration=otio.opentime.from_timecode("00:00:01:12", 24),
+    )
 
-        # Disable top track so we only have one track
-        tl.tracks[1].enabled = False
-        result = otio.adapters.write_to_string(tl, adapter_name="cmx_3600")
-        expected = r'''TITLE: enable_test
+
+def test_transition_duration(cmx_adapter):
+    tl = cmx_adapter.read_from_file(TRANSITION_DURATION_TEST)
+    assert len(tl.tracks[0]) == 5
+
+    assert isinstance(tl.tracks[0][2], otio.schema.Transition)
+
+    assert tl.tracks[0][2].duration().value == 26.0
+
+
+def test_three_part_transition(cmx_adapter):
+    """
+    Test A->B->C Transition
+    """
+    tl = cmx_adapter.read_from_file(DISSOLVE_TEST_4)
+    assert len(tl.tracks[0]) == 8
+
+    assert tl.tracks[0][0].duration().value == 30.0
+    assert tl.tracks[0][1].duration().value == 51.0
+    assert tl.tracks[0][1].visible_range().duration.value == 51 + 35
+    assert isinstance(tl.tracks[0][2], otio.schema.Transition)
+    assert tl.tracks[0][2].duration().value == 35.0
+    assert tl.tracks[0][3].duration().value == 81.0
+    assert tl.tracks[0][3].visible_range().duration.value == 81 + 64
+    assert isinstance(tl.tracks[0][4], otio.schema.Transition)
+    assert tl.tracks[0][4].duration().value == 64.0
+    assert tl.tracks[0][5].duration().value == 84.0
+    assert tl.tracks[0][5].visible_range().duration.value == 84.0
+    assert tl.tracks[0][6].duration().value == 96.0
+    assert tl.tracks[0][7].duration().value == 135.0
+
+
+def test_enabled(cmx_adapter):
+    tl = otio.adapters.read_from_file(ENABLED_TEST)
+    # Exception is raised because the OTIO file has two tracks and cmx_3600 only
+    # supports one
+    with pytest.raises(otio.exceptions.NotSupportedError):
+        cmx_adapter.write_to_string(tl)
+
+    # Disable top track so we only have one track
+    tl.tracks[1].enabled = False
+    result = cmx_adapter.write_to_string(tl)
+    expected = r"""TITLE: enable_test
 
 001  Clip001  V     C        00:00:00:00 00:00:00:03 00:00:00:00 00:00:00:03
 * FROM CLIP NAME:  Clip-001
@@ -1336,22 +1126,18 @@ V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 002  Clip002  V     C        00:00:00:03 00:00:00:06 00:00:00:03 00:00:00:06
 * FROM CLIP NAME:  Clip-002
 * OTIO TRUNCATED REEL NAME FROM: Clip-002
-'''
+"""
 
-        self.assertMultiLineEqual(result, expected)
+    assert result == expected
 
-        # Disable first clip in the track
-        tl.tracks[0].find_children()[0].enabled = False
-        result = otio.adapters.write_to_string(tl, adapter_name="cmx_3600")
-        expected = r'''TITLE: enable_test
+    # Disable first clip in the track
+    tl.tracks[0].find_children()[0].enabled = False
+    result = cmx_adapter.write_to_string(tl)
+    expected = r"""TITLE: enable_test
 
 001  Clip002  V     C        00:00:00:03 00:00:00:06 00:00:00:03 00:00:00:06
 * FROM CLIP NAME:  Clip-002
 * OTIO TRUNCATED REEL NAME FROM: Clip-002
-'''
+"""
 
-        self.assertMultiLineEqual(result, expected)
-
-
-if __name__ == "__main__":
-    unittest.main()
+    assert result == expected


### PR DESCRIPTION
- Bumped versions in dependencies and ci to 0.17.0.dev1 (rather than extract_adapters branch)
- Addressed issue where tests weren't explicit about pulling the adapter from source
- Added `src` directory to pytest's pathing
- refactored tests to be pytest-style

This PR supersedes #7.